### PR TITLE
API-661 Add validation for date and datetime

### DIFF
--- a/src/Query/Filters/DateOperatorFilter.php
+++ b/src/Query/Filters/DateOperatorFilter.php
@@ -9,6 +9,8 @@ use Spatie\QueryBuilder\Filters\FiltersExact;
 
 class DateOperatorFilter extends FiltersExact
 {
+    public function __construct(private readonly string $filterName = '') {}
+
     private const ALLOWED_OPERATORS = [
         FilterOperator::EQUALS,
         FilterOperator::NOT_EQUALS,
@@ -117,6 +119,8 @@ class DateOperatorFilter extends FiltersExact
         $wasArray = is_array($value['value']);
         $filterValue = Arr::wrap($value['value']);
 
+        $this->validateDateValues($filterValue);
+
         // If it wasn't originally an array and we only have one element, extract it
         if (! $wasArray && count($filterValue) === 1) {
             $filterValue = $filterValue[0];
@@ -161,6 +165,18 @@ class DateOperatorFilter extends FiltersExact
                     break;
             }
         });
+    }
+
+    private function validateDateValues(array $values): void
+    {
+        foreach ($values as $value) {
+            $parsed = \DateTimeImmutable::createFromFormat('Y-m-d', $value);
+            if ($parsed === false || $parsed->format('Y-m-d') !== $value) {
+                throw ValidationException::withMessages([
+                    $this->filterName => "The filter value '{$value}' for '{$this->filterName}' is not a valid date. Expected format: Y-m-d.",
+                ]);
+            }
+        }
     }
 
     public function allowedOperators(): array

--- a/src/Query/Filters/DateTimeOperatorFilter.php
+++ b/src/Query/Filters/DateTimeOperatorFilter.php
@@ -9,6 +9,8 @@ use Spatie\QueryBuilder\Filters\FiltersExact;
 
 class DateTimeOperatorFilter extends FiltersExact
 {
+    public function __construct(private readonly string $filterName = '') {}
+
     private const LEGACY_ZERO_DATETIME = '0000-00-00 00:00:00';
 
     private const LEGACY_ZERO_DATE = '0000-00-00';
@@ -121,6 +123,8 @@ class DateTimeOperatorFilter extends FiltersExact
         $wasArray = is_array($value['value']);
         $filterValue = Arr::wrap($value['value']);
 
+        $this->validateDateTimeValues($filterValue);
+
         if (! $wasArray && count($filterValue) === 1) {
             $filterValue = $filterValue[0];
         }
@@ -164,6 +168,28 @@ class DateTimeOperatorFilter extends FiltersExact
                     break;
             }
         });
+    }
+
+    private function validateDateTimeValues(array $values): void
+    {
+        $formats = ['Y-m-d\TH:i:sP', 'Y-m-d H:i:s'];
+
+        foreach ($values as $value) {
+            $valid = false;
+            foreach ($formats as $format) {
+                $parsed = \DateTimeImmutable::createFromFormat($format, $value);
+                if ($parsed !== false && $parsed->format($format) === $value) {
+                    $valid = true;
+                    break;
+                }
+            }
+
+            if (! $valid) {
+                throw ValidationException::withMessages([
+                    $this->filterName => "The filter value '{$value}' for '{$this->filterName}' is not a valid datetime. Expected format: Y-m-d\TH:i:sP or Y-m-d H:i:s.",
+                ]);
+            }
+        }
     }
 
     public function allowedOperators(): array

--- a/src/Query/Filters/QueryFilter.php
+++ b/src/Query/Filters/QueryFilter.php
@@ -31,7 +31,7 @@ class QueryFilter
     {
         return AllowedFilter::custom(
             $name,
-            new DateOperatorFilter,
+            new DateOperatorFilter($name),
             $internalName,
         );
     }
@@ -40,7 +40,7 @@ class QueryFilter
     {
         return AllowedFilter::custom(
             $name,
-            new DateTimeOperatorFilter,
+            new DateTimeOperatorFilter($name),
             $internalName,
         );
     }

--- a/tests/Unit/Query/Filters/DateOperatorFilterTest.php
+++ b/tests/Unit/Query/Filters/DateOperatorFilterTest.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Validation\ValidationException;
+use Workbench\App\Models\Invoice;
+use Xentral\LaravelApi\Query\Filters\DateOperatorFilter;
+
+describe('DateOperatorFilter', function () {
+    describe('valid date values', function () {
+        it('accepts a valid date value', function () {
+            Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
+
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2026-02-16'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+
+        it('accepts valid date array values', function () {
+            Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
+            Invoice::factory()->create(['issued_at' => '2026-02-17 10:00:00']);
+            Invoice::factory()->create(['issued_at' => '2026-02-18 10:00:00']);
+
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => ['2026-02-16', '2026-02-18']], 'issued_at');
+
+            expect($query->count())->toBe(2);
+        });
+    });
+
+    describe('invalid date values', function () {
+        it('skips filter when value is empty', function () {
+            Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
+
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => ''], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+
+        it('throws ValidationException for non-date string', function () {
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => 'not-a-date'], 'issued_at');
+        })->throws(ValidationException::class);
+
+        it('throws ValidationException for invalid month', function () {
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2025-13-01'], 'issued_at');
+        })->throws(ValidationException::class);
+
+        it('throws ValidationException for invalid day', function () {
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2025-02-30'], 'issued_at');
+        })->throws(ValidationException::class);
+
+        it('throws ValidationException for invalid value in array', function () {
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => ['2026-02-16', 'bad', '2026-02-18']], 'issued_at');
+        })->throws(ValidationException::class);
+
+        it('includes filter name and value in error message', function () {
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+
+            try {
+                $filter($query, ['operator' => 'equals', 'value' => 'bad-date'], 'issued_at');
+            } catch (ValidationException $e) {
+                expect($e->errors()['issuedAt'][0])
+                    ->toContain('bad-date')
+                    ->toContain('issuedAt');
+
+                return;
+            }
+
+            $this->fail('Expected ValidationException was not thrown');
+        });
+    });
+
+    describe('isNull and isNotNull operators', function () {
+        it('does not require value validation for isNull', function () {
+            Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
+
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'isNull'], 'issued_at');
+
+            expect($query->count())->toBe(0);
+        });
+
+        it('does not require value validation for isNotNull', function () {
+            Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
+
+            $filter = new DateOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'isNotNull'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+    });
+});

--- a/tests/Unit/Query/Filters/DateTimeOperatorFilterTest.php
+++ b/tests/Unit/Query/Filters/DateTimeOperatorFilterTest.php
@@ -222,6 +222,65 @@ describe('DateTimeOperatorFilter', function () {
         });
     });
 
+    describe('invalid datetime values', function () {
+        it('throws ValidationException for non-datetime string', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => 'not-a-datetime'], 'issued_at');
+        })->throws(ValidationException::class);
+
+        it('throws ValidationException for date-only value', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2026-02-16'], 'issued_at');
+        })->throws(ValidationException::class);
+
+        it('throws ValidationException for invalid month in datetime', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2025-13-01 10:00:00'], 'issued_at');
+        })->throws(ValidationException::class);
+
+        it('throws ValidationException for invalid leap year', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2026-02-29 10:00:00'], 'issued_at');
+        })->throws(ValidationException::class);
+
+        it('throws ValidationException for invalid value in array', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => ['2026-02-16 10:00:00', 'bad']], 'issued_at');
+        })->throws(ValidationException::class);
+
+        it('accepts ISO 8601 format', function () {
+            Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
+
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'greaterThan', 'value' => '2026-02-15T10:00:00+00:00'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+
+        it('includes filter name and value in error message', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+
+            try {
+                $filter($query, ['operator' => 'equals', 'value' => 'bad'], 'issued_at');
+            } catch (ValidationException $e) {
+                expect($e->errors()['issuedAt'][0])
+                    ->toContain('bad')
+                    ->toContain('issuedAt');
+
+                return;
+            }
+
+            $this->fail('Expected ValidationException was not thrown');
+        });
+    });
+
     describe('multiple filters', function () {
         it('applies multiple filters via nested arrays', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 08:00:00']);


### PR DESCRIPTION
This pull request adds strict validation for date and datetime filter values, ensuring only properly formatted and valid dates/datetimes are accepted in query filters. It introduces custom error messages that include the filter name and invalid value, and updates the filter constructors to accept a filter name for improved error reporting. Comprehensive unit tests are added to verify the new validation logic and error handling.

**Validation improvements:**

* Added `validateDateValues` and `validateDateTimeValues` methods to `DateOperatorFilter` and `DateTimeOperatorFilter`, respectively, to enforce strict date (`Y-m-d`) and datetime (`Y-m-d\TH:i:sP` or `Y-m-d H:i:s`) formats and throw `ValidationException` with descriptive messages if validation fails. [[1]](diffhunk://#diff-e886138fe9c19290bdb55b0cd5a07de01d5e0225483e8f8a8830960951661a0fR122-R123) [[2]](diffhunk://#diff-e886138fe9c19290bdb55b0cd5a07de01d5e0225483e8f8a8830960951661a0fR170-R181) [[3]](diffhunk://#diff-33a311b7970e20c6af4e0ed23776ca3ea4e0e208f8045b088cee938e7b740a3dR126-R127) [[4]](diffhunk://#diff-33a311b7970e20c6af4e0ed23776ca3ea4e0e208f8045b088cee938e7b740a3dR173-R194)

**Constructor and usage changes:**

* Modified constructors of `DateOperatorFilter` and `DateTimeOperatorFilter` to accept a `filterName` parameter, allowing error messages to reference the specific filter. Updated their usage in `QueryFilter` static methods. [[1]](diffhunk://#diff-e886138fe9c19290bdb55b0cd5a07de01d5e0225483e8f8a8830960951661a0fR12-R13) [[2]](diffhunk://#diff-33a311b7970e20c6af4e0ed23776ca3ea4e0e208f8045b088cee938e7b740a3dR12-R13) [[3]](diffhunk://#diff-f379e0b0df0253458160dc9df31b53ee02462dba8b2891fac052b5a2d13bba03L34-R34) [[4]](diffhunk://#diff-f379e0b0df0253458160dc9df31b53ee02462dba8b2891fac052b5a2d13bba03L43-R43)

**Testing enhancements:**

* Added comprehensive unit tests for `DateOperatorFilter`, covering valid/invalid values, array handling, and error message content.
* Expanded `DateTimeOperatorFilter` tests to cover invalid values, ISO 8601 acceptance, and error message details.