### PR TITLE
API-792: datetime filters compare app-timezone wall clock and accept plain dates

### DIFF
--- a/src/OpenApi/Filters/DateFilter.php
+++ b/src/OpenApi/Filters/DateFilter.php
@@ -16,6 +16,8 @@ class DateFilter extends FilterProperty
             FilterOperator::LESS_THAN_OR_EQUALS,
             FilterOperator::GREATER_THAN,
             FilterOperator::GREATER_THAN_OR_EQUALS,
+            FilterOperator::IS_NULL,
+            FilterOperator::IS_NOT_NULL,
         ],
     ) {
         parent::__construct(

--- a/src/Query/Filters/DateOperatorFilter.php
+++ b/src/Query/Filters/DateOperatorFilter.php
@@ -9,7 +9,7 @@ use Spatie\QueryBuilder\Filters\FiltersExact;
 
 class DateOperatorFilter extends FiltersExact
 {
-    public function __construct(private readonly string $filterName = '') {}
+    public function __construct(private readonly string $filterName) {}
 
     private const ALLOWED_OPERATORS = [
         FilterOperator::EQUALS,

--- a/src/Query/Filters/DateTimeOperatorFilter.php
+++ b/src/Query/Filters/DateTimeOperatorFilter.php
@@ -9,7 +9,7 @@ use Spatie\QueryBuilder\Filters\FiltersExact;
 
 class DateTimeOperatorFilter extends FiltersExact
 {
-    public function __construct(private readonly string $filterName = '') {}
+    public function __construct(private readonly string $filterName) {}
 
     private const LEGACY_ZERO_DATETIME = '0000-00-00 00:00:00';
 

--- a/src/Query/Filters/DateTimeOperatorFilter.php
+++ b/src/Query/Filters/DateTimeOperatorFilter.php
@@ -120,65 +120,94 @@ class DateTimeOperatorFilter extends FiltersExact
             return;
         }
 
-        $wasArray = is_array($value['value']);
         $filterValue = Arr::wrap($value['value']);
 
         $this->validateDateTimeValues($filterValue);
 
-        $filterValue = array_map(function (string $val): string {
-            $parsed = new \DateTimeImmutable($val);
-
-            return $parsed->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s');
-        }, $filterValue);
-
-        if (! $wasArray && count($filterValue) === 1) {
-            $filterValue = $filterValue[0];
-        }
+        $filterValue = $this->resolveFilterValues($filterValue);
 
         $query->where(function (Builder $query) use ($filterValue, $operator, $property) {
-            switch ($operator) {
-                case FilterOperator::EQUALS:
-                    if (is_array($filterValue)) {
-                        foreach ($filterValue as $val) {
-                            $query->orWhere($query->qualifyColumn($property), '=', $val);
+            $column = $query->qualifyColumn($property);
+
+            foreach ($filterValue as $val) {
+                switch ($operator) {
+                    case FilterOperator::EQUALS:
+                        if (is_array($val)) {
+                            $query->orWhere(function (Builder $query) use ($column, $val) {
+                                $query->where($column, '>=', $val['start'])->where($column, '<', $val['end']);
+                            });
+                        } else {
+                            $query->orWhere($column, '=', $val);
                         }
-                    } else {
-                        $query->where($query->qualifyColumn($property), '=', $filterValue);
-                    }
-                    break;
+                        break;
 
-                case FilterOperator::NOT_EQUALS:
-                    if (is_array($filterValue)) {
-                        foreach ($filterValue as $val) {
-                            $query->where($query->qualifyColumn($property), '!=', $val);
+                    case FilterOperator::NOT_EQUALS:
+                        if (is_array($val)) {
+                            $query->where(function (Builder $query) use ($column, $val) {
+                                $query->where($column, '<', $val['start'])->orWhere($column, '>=', $val['end']);
+                            });
+                        } else {
+                            $query->where($column, '!=', $val);
                         }
-                    } else {
-                        $query->where($query->qualifyColumn($property), '!=', $filterValue);
-                    }
-                    break;
+                        break;
 
-                case FilterOperator::LESS_THAN:
-                    $query->where($query->qualifyColumn($property), '<', $filterValue);
-                    break;
+                    case FilterOperator::LESS_THAN:
+                        $query->where($column, '<', is_array($val) ? $val['start'] : $val);
+                        break;
 
-                case FilterOperator::LESS_THAN_OR_EQUALS:
-                    $query->where($query->qualifyColumn($property), '<=', $filterValue);
-                    break;
+                    case FilterOperator::LESS_THAN_OR_EQUALS:
+                        if (is_array($val)) {
+                            $query->where($column, '<', $val['end']);
+                        } else {
+                            $query->where($column, '<=', $val);
+                        }
+                        break;
 
-                case FilterOperator::GREATER_THAN:
-                    $query->where($query->qualifyColumn($property), '>', $filterValue);
-                    break;
+                    case FilterOperator::GREATER_THAN:
+                        if (is_array($val)) {
+                            $query->where($column, '>=', $val['end']);
+                        } else {
+                            $query->where($column, '>', $val);
+                        }
+                        break;
 
-                case FilterOperator::GREATER_THAN_OR_EQUALS:
-                    $query->where($query->qualifyColumn($property), '>=', $filterValue);
-                    break;
+                    case FilterOperator::GREATER_THAN_OR_EQUALS:
+                        $query->where($column, '>=', is_array($val) ? $val['start'] : $val);
+                        break;
+                }
             }
         });
     }
 
+    /**
+     * Resolves each value to an app-timezone wall clock instant, or to a
+     * day interval (start inclusive, end exclusive) for plain Y-m-d dates.
+     *
+     * @param  list<string>  $values
+     * @return list<string|array{start: string, end: string}>
+     */
+    private function resolveFilterValues(array $values): array
+    {
+        $appTimezone = new \DateTimeZone(config('app.timezone'));
+
+        return array_map(function (string $value) use ($appTimezone): string|array {
+            $day = \DateTimeImmutable::createFromFormat('!Y-m-d', $value, $appTimezone);
+            if ($day instanceof \DateTimeImmutable && $day->format('Y-m-d') === $value) {
+                return [
+                    'start' => $day->format('Y-m-d H:i:s'),
+                    'end' => $day->modify('+1 day')->format('Y-m-d H:i:s'),
+                ];
+            }
+
+            return (new \DateTimeImmutable($value, $appTimezone))
+                ->setTimezone($appTimezone)
+                ->format('Y-m-d H:i:s');
+        }, $values);
+    }
+
     private function validateDateTimeValues(array $values): void
     {
-        $formats = ['Y-m-d\TH:i:sP', 'Y-m-d H:i:s'];
+        $formats = ['Y-m-d\TH:i:sP', 'Y-m-d\TH:i:s', 'Y-m-d H:i:s', 'Y-m-d'];
 
         foreach ($values as $value) {
             $valid = false;
@@ -192,7 +221,7 @@ class DateTimeOperatorFilter extends FiltersExact
 
             if (! $valid) {
                 throw ValidationException::withMessages([
-                    $this->filterName => "The filter value '{$value}' for '{$this->filterName}' is not a valid datetime. Expected format: Y-m-d\TH:i:sP or Y-m-d H:i:s.",
+                    $this->filterName => "The filter value '{$value}' for '{$this->filterName}' is not a valid datetime. Expected format: Y-m-d\TH:i:sP, Y-m-d\TH:i:s, Y-m-d H:i:s or Y-m-d.",
                 ]);
             }
         }

--- a/tests/Unit/OpenApi/Filters/DateFilterTest.php
+++ b/tests/Unit/OpenApi/Filters/DateFilterTest.php
@@ -7,7 +7,7 @@ use Xentral\LaravelApi\Query\Filters\FilterOperator;
 it('documents the same operators as the runtime date filter by default', function () {
     $filter = new DateFilter(name: 'issuedAt');
 
-    expect($filter->operators)->toBe((new DateOperatorFilter)->allowedOperators());
+    expect($filter->operators)->toBe((new DateOperatorFilter('issuedAt'))->allowedOperators());
 });
 
 it('documents isNull and isNotNull by default', function () {

--- a/tests/Unit/OpenApi/Filters/DateFilterTest.php
+++ b/tests/Unit/OpenApi/Filters/DateFilterTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+use Xentral\LaravelApi\OpenApi\Filters\DateFilter;
+use Xentral\LaravelApi\Query\Filters\DateOperatorFilter;
+use Xentral\LaravelApi\Query\Filters\FilterOperator;
+
+it('documents the same operators as the runtime date filter by default', function () {
+    $filter = new DateFilter(name: 'issuedAt');
+
+    expect($filter->operators)->toBe((new DateOperatorFilter)->allowedOperators());
+});
+
+it('documents isNull and isNotNull by default', function () {
+    $filter = new DateFilter(name: 'issuedAt');
+
+    expect($filter->operators)->toContain(FilterOperator::IS_NULL)
+        ->and($filter->operators)->toContain(FilterOperator::IS_NOT_NULL);
+});
+
+it('allows custom operators', function () {
+    $filter = new DateFilter(name: 'issuedAt', operators: [FilterOperator::EQUALS]);
+
+    expect($filter->operators)->toBe([FilterOperator::EQUALS]);
+});

--- a/tests/Unit/Query/Filters/DateOperatorFilterTest.php
+++ b/tests/Unit/Query/Filters/DateOperatorFilterTest.php
@@ -80,6 +80,10 @@ describe('DateOperatorFilter', function () {
 
             $this->fail('Expected ValidationException was not thrown');
         });
+
+        it('requires a filter name at construction', function () {
+            new DateOperatorFilter;
+        })->throws(ArgumentCountError::class);
     });
 
     describe('isNull and isNotNull operators', function () {

--- a/tests/Unit/Query/Filters/DateTimeOperatorFilterTest.php
+++ b/tests/Unit/Query/Filters/DateTimeOperatorFilterTest.php
@@ -229,10 +229,10 @@ describe('DateTimeOperatorFilter', function () {
             $filter($query, ['operator' => 'equals', 'value' => 'not-a-datetime'], 'issued_at');
         })->throws(ValidationException::class);
 
-        it('throws ValidationException for date-only value', function () {
+        it('throws ValidationException for invalid month in plain date', function () {
             $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
-            $filter($query, ['operator' => 'equals', 'value' => '2026-02-16'], 'issued_at');
+            $filter($query, ['operator' => 'equals', 'value' => '2024-13-01'], 'issued_at');
         })->throws(ValidationException::class);
 
         it('throws ValidationException for invalid month in datetime', function () {
@@ -303,6 +303,144 @@ describe('DateTimeOperatorFilter', function () {
             }
 
             $this->fail('Expected ValidationException was not thrown');
+        });
+    });
+
+    describe('app timezone handling', function () {
+        beforeEach(function () {
+            config(['app.timezone' => 'Europe/Berlin']);
+            date_default_timezone_set('Europe/Berlin');
+        });
+
+        afterEach(function () {
+            date_default_timezone_set('UTC');
+        });
+
+        it('matches a row when filtering equals with the value the API returns', function () {
+            Invoice::factory()->create(['issued_at' => '2026-01-15 10:30:00']);
+
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2026-01-15T10:30:00+01:00'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+
+        it('matches a row when filtering equals with the documented zoneless format', function () {
+            Invoice::factory()->create(['issued_at' => '2026-01-15 10:30:00']);
+
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2026-01-15 10:30:00'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+
+        it('does not match a row when filtering equals with the same wall clock at a different offset', function () {
+            Invoice::factory()->create(['issued_at' => '2026-01-15 10:30:00']);
+
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2026-01-15T10:30:00+00:00'], 'issued_at');
+
+            expect($query->count())->toBe(0);
+        });
+
+        it('includes the creation instant when filtering lessThanOrEquals with the value the API returns', function () {
+            Invoice::factory()->create(['issued_at' => '2026-01-15 10:30:00']);
+
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'lessThanOrEquals', 'value' => '2026-01-15T10:30:00+01:00'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+
+        it('converts offsets to app timezone wall clock for comparisons', function () {
+            Invoice::factory()->create(['issued_at' => '2026-01-15 12:00:00']);
+
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2026-01-15T11:00:00+00:00'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+    });
+
+    describe('zoneless ISO datetime values', function () {
+        it('accepts ISO datetime without offset and interprets it in app timezone', function () {
+            Invoice::factory()->create(['issued_at' => '2026-01-15 10:30:00']);
+
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2026-01-15T10:30:00'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+    });
+
+    describe('plain date values with day interval semantics', function () {
+        beforeEach(function () {
+            Invoice::factory()->create(['issued_at' => '2024-11-20 23:59:59']);
+            Invoice::factory()->create(['issued_at' => '2024-11-21 00:00:00']);
+            Invoice::factory()->create(['issued_at' => '2024-11-21 15:00:00']);
+            Invoice::factory()->create(['issued_at' => '2024-11-22 00:00:00']);
+        });
+
+        it('matches the whole day with equals', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => '2024-11-21'], 'issued_at');
+
+            expect($query->count())->toBe(2);
+        });
+
+        it('excludes the whole day with notEquals', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'notEquals', 'value' => '2024-11-21'], 'issued_at');
+
+            expect($query->count())->toBe(2);
+        });
+
+        it('starts at the day start with greaterThanOrEquals', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'greaterThanOrEquals', 'value' => '2024-11-21'], 'issued_at');
+
+            expect($query->count())->toBe(3);
+        });
+
+        it('starts at the next day start with greaterThan', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'greaterThan', 'value' => '2024-11-21'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+
+        it('ends before the day start with lessThan', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'lessThan', 'value' => '2024-11-21'], 'issued_at');
+
+            expect($query->count())->toBe(1);
+        });
+
+        it('ends before the next day start with lessThanOrEquals', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'lessThanOrEquals', 'value' => '2024-11-21'], 'issued_at');
+
+            expect($query->count())->toBe(3);
+        });
+
+        it('matches mixed plain date and datetime values with equals', function () {
+            $filter = new DateTimeOperatorFilter('issuedAt');
+            $query = Invoice::query();
+            $filter($query, ['operator' => 'equals', 'value' => ['2024-11-21', '2024-11-22 00:00:00']], 'issued_at');
+
+            expect($query->count())->toBe(3);
         });
     });
 

--- a/tests/Unit/Query/Filters/DateTimeOperatorFilterTest.php
+++ b/tests/Unit/Query/Filters/DateTimeOperatorFilterTest.php
@@ -11,7 +11,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 09:00:00']);
             Invoice::factory()->create(['issued_at' => '2026-02-16 11:00:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'greaterThan', 'value' => '2026-02-16 10:00:00'], 'issued_at');
 
@@ -23,7 +23,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 09:00:00']);
             Invoice::factory()->create(['issued_at' => '2026-02-16 11:00:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'lessThan', 'value' => '2026-02-16 10:00:00'], 'issued_at');
 
@@ -35,7 +35,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
             Invoice::factory()->create(['issued_at' => '2026-02-16 10:30:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'equals', 'value' => '2026-02-16 10:00:00'], 'issued_at');
 
@@ -47,7 +47,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
             Invoice::factory()->create(['issued_at' => '2026-02-16 10:30:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'notEquals', 'value' => '2026-02-16 10:00:00'], 'issued_at');
 
@@ -60,7 +60,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
             Invoice::factory()->create(['issued_at' => '2026-02-16 11:00:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'greaterThanOrEquals', 'value' => '2026-02-16 10:00:00'], 'issued_at');
 
@@ -72,7 +72,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
             Invoice::factory()->create(['issued_at' => '2026-02-16 11:00:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'lessThanOrEquals', 'value' => '2026-02-16 10:00:00'], 'issued_at');
 
@@ -85,7 +85,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['paid_at' => null]);
             Invoice::factory()->create(['paid_at' => '2026-02-16 10:00:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('paidAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'isNull'], 'paid_at');
 
@@ -96,7 +96,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['paid_at' => null]);
             Invoice::factory()->create(['paid_at' => '2026-02-16 10:00:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('paidAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'isNotNull'], 'paid_at');
 
@@ -116,7 +116,7 @@ describe('DateTimeOperatorFilter', function () {
                 'issued_at' => now(),
             ]);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('paidAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'isNull'], 'paid_at');
 
@@ -136,7 +136,7 @@ describe('DateTimeOperatorFilter', function () {
                 'issued_at' => now(),
             ]);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('paidAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'isNull'], 'paid_at');
 
@@ -155,7 +155,7 @@ describe('DateTimeOperatorFilter', function () {
                 'issued_at' => now(),
             ]);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('paidAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'isNotNull'], 'paid_at');
 
@@ -174,7 +174,7 @@ describe('DateTimeOperatorFilter', function () {
                 'issued_at' => now(),
             ]);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('paidAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'isNotNull'], 'paid_at');
 
@@ -188,7 +188,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
             Invoice::factory()->create(['issued_at' => '2026-02-16 11:00:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'equals', 'value' => ['2026-02-16 09:00:00', '2026-02-16 11:00:00']], 'issued_at');
 
@@ -198,13 +198,13 @@ describe('DateTimeOperatorFilter', function () {
 
     describe('unsupported operators', function () {
         it('throws ValidationException for contains operator', function () {
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'contains', 'value' => '2026-02-16'], 'issued_at');
         })->throws(ValidationException::class);
 
         it('throws ValidationException for invalid operator', function () {
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'invalidOp', 'value' => '2026-02-16'], 'issued_at');
         })->throws(ValidationException::class);
@@ -214,7 +214,7 @@ describe('DateTimeOperatorFilter', function () {
         it('skips filter when value is empty', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, ['operator' => 'equals', 'value' => ''], 'issued_at');
 
@@ -304,6 +304,10 @@ describe('DateTimeOperatorFilter', function () {
 
             $this->fail('Expected ValidationException was not thrown');
         });
+
+        it('requires a filter name at construction', function () {
+            new DateTimeOperatorFilter;
+        })->throws(ArgumentCountError::class);
     });
 
     describe('app timezone handling', function () {
@@ -450,7 +454,7 @@ describe('DateTimeOperatorFilter', function () {
             Invoice::factory()->create(['issued_at' => '2026-02-16 10:00:00']);
             Invoice::factory()->create(['issued_at' => '2026-02-16 12:00:00']);
 
-            $filter = new DateTimeOperatorFilter;
+            $filter = new DateTimeOperatorFilter('issuedAt');
             $query = Invoice::query();
             $filter($query, [
                 ['operator' => 'greaterThan', 'value' => '2026-02-16 09:00:00'],

--- a/workbench/openapi.yml
+++ b/workbench/openapi.yml
@@ -195,7 +195,7 @@ paths:
         -
           name: filter
           in: query
-          description: "The filter parameter is used to filter the results of the given endpoint. \n\n\n**Supported filter operators by key:** \n\n`id`: *equals*, *notEquals*, *in*, *notIn* \n\n`invoice_number`: *equals*, *notEquals*, *in*, *notIn*, *contains*, *notContains*, *startsWith*, *endsWith* \n\n`status`: *equals*, *notEquals*, *in*, *notIn* \n\n`issued_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals* \n\n`due_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals* \n\n`paid_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals* \n\n`created_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals* \n\n`updated_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals*"
+          description: "The filter parameter is used to filter the results of the given endpoint. \n\n\n**Supported filter operators by key:** \n\n`id`: *equals*, *notEquals*, *in*, *notIn* \n\n`invoice_number`: *equals*, *notEquals*, *in*, *notIn*, *contains*, *notContains*, *startsWith*, *endsWith* \n\n`status`: *equals*, *notEquals*, *in*, *notIn* \n\n`issued_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals*, *isNull*, *isNotNull* \n\n`due_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals*, *isNull*, *isNotNull* \n\n`paid_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals*, *isNull*, *isNotNull* \n\n`created_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals*, *isNull*, *isNotNull* \n\n`updated_at`: *equals*, *notEquals*, *lessThan*, *lessThanOrEquals*, *greaterThan*, *greaterThanOrEquals*, *isNull*, *isNotNull*"
           required: false
           style: deepObject
           schema:
@@ -208,7 +208,7 @@ paths:
                 op:
                   description: operator
                   type: string
-                  enum: [equals, notEquals, in, notIn, contains, notContains, startsWith, endsWith, lessThan, lessThanOrEquals, greaterThan, greaterThanOrEquals]
+                  enum: [equals, notEquals, in, notIn, contains, notContains, startsWith, endsWith, lessThan, lessThanOrEquals, greaterThan, greaterThanOrEquals, isNull, isNotNull]
                 value:
                   description: 'The property value.'
                   oneOf: [{ title: String, type: string }, { title: Array, type: array, items: { type: string } }]


### PR DESCRIPTION
## Summary

Fixes [API-792](https://xentral.atlassian.net/browse/API-792) — filtering with the exact `createdAt`/`updatedAt` value the API returns found nothing, because `DateTimeOperatorFilter` shifted filter input to UTC before comparing it against columns that hold app-timezone wall clock.

- **Timezone fix:** filter input is now resolved to `config('app.timezone')` wall clock (zoned values are converted; zoneless values are interpreted in the app timezone). Filtering with the API's own read value (`2026-01-15T10:30:00+01:00`) now matches.
- **Plain dates on datetime filters:** `Y-m-d` values are accepted with day-interval semantics (ISO 8601 reduced precision) — `equals 2024-11-21` resolves to `>= 2024-11-21 00:00:00 AND < 2024-11-22 00:00:00`, `notEquals` to its complement, `greaterThan` starts at the next day, `lessThanOrEquals` ends before the next day. Works inside array values mixed with exact datetimes.
- **Zoneless ISO datetimes:** `Y-m-d\TH:i:s` (no offset) is now accepted on datetime filters and interpreted in the app timezone, consistent with `Y-m-d H:i:s` (ticket item 3, implemented as proposed).
- **Docs parity:** OpenApi `DateFilter` defaults now document `isNull`/`isNotNull`, matching the runtime `DateOperatorFilter`; `workbench/openapi.yml` updated accordingly.
- **Hardening:** `$filterName` is now required on `DateOperatorFilter` and `DateTimeOperatorFilter` (the `= ''` default let direct instantiations key `ValidationException`s by an empty string), matching `NumberOperatorFilter` since 6d04a2c. `QueryFilter::date()`/`::datetime()` always pass a name, so real call paths are unaffected.

## Test plan

- 15 new tests written first (TDD) in `DateTimeOperatorFilterTest` and the new `DateFilterTest`, covering the ticket's reproduction (app timezone Europe/Berlin, row at `2026-01-15 10:30:00`): `equals` with the API read value matches, the wrong instant `+00:00` no longer matches, `lessThanOrEquals` includes the creation instant, plus all six operators against plain-date day boundaries.
- 2 further tests assert both operator filters can no longer be constructed without a filter name.
- Full suite green after rebase: 419 passed (the previously noted time-based failures were fixed on `main` in fe138fc).
- Pint and PHPStan clean.

Consumer-side changes (xentral repo) are tracked in API-793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[API-792]: https://xentral.atlassian.net/browse/API-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ