### PR TITLE
API-790 Consolidate reusable filter mechanics (truthy integer flags, callback id filter, shared coercion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Everything else is owned by the filter:
 - supported operators are `equals`, `notEquals`, `in` and `notIn`; anything else is a validation error
 - every id must be numeric and reaches the callback cast to `int`
 - the callback is guaranteed a non-empty list, so `notIn` can never degrade into "match everything"
+- every invocation of the callback is wrapped in its own nested `where`, so a predicate using
+  `orWhere` cannot widen the query it is applied to
 - `notEquals` and `notIn` negate the predicate, so both mean "matches none of these ids"
 - `equals` with several ids on an `IdFilterTarget::Relation` requires **all** of them and applies the
   predicate once per id, consistent with relation filters elsewhere in this package. On an

--- a/README.md
+++ b/README.md
@@ -230,6 +230,77 @@ contains `key`, `op`, and `value` parameters. Here are some examples:
 /api/v1/sales-orders?filter[0][key]=customer.name&filter[0][op]=contains&filter[0][value]=John
 ```
 
+##### Truthy integer flags
+
+`QueryFilter::booleanInteger()` filters a legacy integer column that is semantically boolean. It
+matches by *truthiness*, not by an exact `1`, because consumers expose such a column as
+`(bool) $row->column`:
+
+| Filter | SQL |
+|---|---|
+| `equals true`, `notEquals false` | `column > 0` |
+| `equals false`, `notEquals true` | `(column = 0 or column is null)` |
+
+`false` deliberately matches `NULL`. A `NULL` is rendered as `false` in the payload, so a filter
+skipping those rows would contradict what the API returns for them.
+
+Accepted values are `true`, `1`, `'1'`, `'true'` and `false`, `0`, `'0'`, `'false'`; anything else is
+a validation error. Only `equals` and `notEquals` are supported.
+
+A negative value matches neither side, even though PHP would cast it to `true` - the filter exists
+for columns holding `0`, `1` or `NULL`. Use `QueryFilter::number()` if a column carries real
+quantities.
+
+##### Id filters on relations and expressions
+
+`QueryFilter::identifier()` resolves to a column. When the target is a computed predicate instead -
+a pivot relation, or a legacy column that stores the id inside another value - use
+`QueryFilter::identifierCallback()` and hand it that predicate:
+
+```php
+use Illuminate\Database\Eloquent\Builder;
+use Xentral\LaravelApi\Query\Filters\IdFilterTarget;
+use Xentral\LaravelApi\Query\Filters\QueryFilter;
+
+QueryFilter::identifierCallback(
+    'categories.id',
+    fn (Builder $query, array $ids) => $query->whereHas(
+        'categories',
+        fn (Builder $categories) => $categories->whereIn('product_category.id', $ids),
+    ),
+    IdFilterTarget::Relation,
+),
+```
+
+The callback does one thing: constrain the query to rows matching **any** of the ids it receives.
+Everything else is owned by the filter:
+
+- supported operators are `equals`, `notEquals`, `in` and `notIn`; anything else is a validation error
+- every id must be numeric and reaches the callback cast to `int`
+- the callback is guaranteed a non-empty list, so `notIn` can never degrade into "match everything"
+- `notEquals` and `notIn` negate the predicate, so both mean "matches none of these ids"
+- `equals` with several ids on an `IdFilterTarget::Relation` requires **all** of them and applies the
+  predicate once per id, consistent with relation filters elsewhere in this package. On an
+  `IdFilterTarget::Column` it stays "any of them", because one column cannot hold two values at once
+
+Pair it with the `IdFilter` spec attribute, which exposes exactly the same four operators.
+
+##### Reusing the filter value coercion
+
+Filters that build their own predicate - a relation based boolean filter using
+`whereHas`/`whereDoesntHave`, for instance - should not re-implement the accepted value spellings.
+`FilterValue` exposes the coercion the packaged filters use:
+
+```php
+use Xentral\LaravelApi\Query\Filters\FilterValue;
+
+FilterValue::toBool($value['value'], $property);  // true|1|'1'|'true' / false|0|'0'|'false'
+FilterValue::toIds($value['value'], $property);   // non-empty list<int>
+```
+
+Both throw a `ValidationException` carrying the messages documented above, so a hand-written filter
+stays consistent with the packaged ones.
+
 #### Pagination
 
 This package provides flexible pagination options that can be configured per endpoint. You can choose from three different pagination types, each optimized for different use cases:

--- a/README.md
+++ b/README.md
@@ -296,12 +296,15 @@ Filters that build their own predicate - a relation based boolean filter using
 ```php
 use Xentral\LaravelApi\Query\Filters\FilterValue;
 
-FilterValue::toBool($value['value'], $property);  // true|1|'1'|'true' / false|0|'0'|'false'
-FilterValue::toIds($value['value'], $property);   // non-empty list<int>
+FilterValue::toBool($value['value'], $filterName);  // true|1|'1'|'true' / false|0|'0'|'false'
+FilterValue::toIds($value['value'], $filterName);   // non-empty list<int>
 ```
 
 Both throw a `ValidationException` carrying the messages documented above, so a hand-written filter
-stays consistent with the packaged ones.
+stays consistent with the packaged ones. The second argument keys that exception, so pass the API
+facing filter name - not the `$property` a filter receives, which is the internal column name when
+one is mapped. The packaged filters take the name for exactly this reason, as in
+`QueryFilter::booleanInteger('isVariant', 'variante')`, which reports errors under `isVariant`.
 
 #### Pagination
 

--- a/resources/boost/guidelines/core.md
+++ b/resources/boost/guidelines/core.md
@@ -21,7 +21,7 @@ A Laravel package (namespace `Xentral\LaravelApi`) providing strongly-typed PHP 
 Filtering requires **two parallel declarations** that must stay in sync:
 
 1. **OpenAPI spec layer**: `FilterParameter` with typed filter attributes (`IdFilter`, `StringFilter`, `NumberFilter`, `DateFilter`, `DateTimeFilter`, `EnumFilter`, `BooleanFilter`)
-2. **QueryBuilder layer**: `QueryFilter::identifier()`, `::string()`, `::number()`, `::date()`, `::datetime()`, `::boolean()`, `::booleanInteger()`
+2. **QueryBuilder layer**: `QueryFilter::identifier()`, `::identifierCallback()`, `::string()`, `::number()`, `::date()`, `::datetime()`, `::boolean()`, `::booleanInteger()`
 
 Both layers must declare the same filter names. API field names use camelCase; map to internal column name via the second parameter (e.g. `QueryFilter::date('documentDate', 'datum')`).
 

--- a/resources/boost/skills/api-development/SKILL.md
+++ b/resources/boost/skills/api-development/SKILL.md
@@ -343,6 +343,7 @@ All filter classes live in `Xentral\LaravelApi\OpenApi\Filters\` and extend `Fil
 | QueryFilter Method | Operators |
 |---|---|
 | `QueryFilter::identifier()` | equals, notEquals, in, notIn, isNull, isNotNull |
+| `QueryFilter::identifierCallback()` | equals, notEquals, in, notIn |
 | `QueryFilter::string()` | equals, notEquals, in, notIn, contains, notContains, startsWith, endsWith, isNull, isNotNull |
 | `QueryFilter::number()` | equals, notEquals, lessThan, lessThanOrEquals, greaterThan, greaterThanOrEquals, isNull, isNotNull |
 | `QueryFilter::date()` | equals, notEquals, lessThan, lessThanOrEquals, greaterThan, greaterThanOrEquals, isNull, isNotNull |
@@ -364,6 +365,8 @@ Both layers must be declared for every filter. Use this mapping:
 | `DateTimeFilter(name: 'createdAt')` | `QueryFilter::datetime('createdAt', 'created_at')` | |
 | `EnumFilter(name: 'status', enumSource: E::class)` | `QueryFilter::string('status', enum: E::class)` | Pass enum class to both |
 | `BooleanFilter(name: 'isActive')` | `QueryFilter::boolean('isActive', 'is_active')` | |
+| `BooleanFilter(name: 'isVariant')` | `QueryFilter::booleanInteger('isVariant', 'variante')` | Legacy integer flag: `true` is `> 0`, `false` is `= 0 or is null` |
+| `IdFilter(name: 'categories.id')` | `QueryFilter::identifierCallback('categories.id', $apply, IdFilterTarget::Relation)` | When the id target is a relation or an expression, not a column |
 
 ## Sorting
 

--- a/src/Query/Filters/BooleanIntegerFilter.php
+++ b/src/Query/Filters/BooleanIntegerFilter.php
@@ -16,6 +16,8 @@ class BooleanIntegerFilter implements Filter
 {
     use HasRepeatedFilterKeys;
 
+    public function __construct(private readonly string $filterName) {}
+
     public function __invoke(Builder $query, mixed $value, string $property): void
     {
         if ($this->applyRepeatedFilters($query, $value, $property)) {
@@ -23,12 +25,12 @@ class BooleanIntegerFilter implements Filter
         }
 
         $operator = $value['operator'] ?? 'equals';
-        $isTruthy = FilterValue::toBool($value['value'], $property);
+        $isTruthy = FilterValue::toBool($value['value'], $this->filterName);
 
         $matchesTruthy = match ($operator) {
             'equals' => $isTruthy,
             'notEquals' => ! $isTruthy,
-            default => throw ValidationException::withMessages([$property => "Unsupported operator: {$operator}. Use 'equals' or 'notEquals'."]),
+            default => throw ValidationException::withMessages([$this->filterName => "Unsupported operator: {$operator}. Use 'equals' or 'notEquals'."]),
         };
 
         $column = $query->qualifyColumn($property);

--- a/src/Query/Filters/BooleanIntegerFilter.php
+++ b/src/Query/Filters/BooleanIntegerFilter.php
@@ -25,7 +25,7 @@ class BooleanIntegerFilter implements Filter
         }
 
         $operator = $value['operator'] ?? 'equals';
-        $isTruthy = FilterValue::toBool($value['value'], $this->filterName);
+        $isTruthy = FilterValue::toBool($value['value'] ?? null, $this->filterName);
 
         $matchesTruthy = match ($operator) {
             'equals' => $isTruthy,

--- a/src/Query/Filters/BooleanIntegerFilter.php
+++ b/src/Query/Filters/BooleanIntegerFilter.php
@@ -6,37 +6,41 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Validation\ValidationException;
 use Spatie\QueryBuilder\Filters\Filter;
 
+/**
+ * Filters a legacy integer flag column by truthiness rather than by an exact 1.
+ *
+ * Consumers expose such columns as `(bool) $row->column`, so the filter mirrors
+ * that cast: any value greater than zero is true, zero and NULL are false.
+ */
 class BooleanIntegerFilter implements Filter
 {
+    use HasRepeatedFilterKeys;
+
     public function __invoke(Builder $query, mixed $value, string $property): void
     {
-        if (isset($value[0]) && is_array($value[0])) {
-            foreach ($value as $filter) {
-                $this->__invoke($query, $filter, $property);
-            }
-
+        if ($this->applyRepeatedFilters($query, $value, $property)) {
             return;
         }
 
         $operator = $value['operator'] ?? 'equals';
-        $filterValue = $value['value'];
-        $dbValue = $this->toDbValue($filterValue, $property);
+        $isTruthy = FilterValue::toBool($value['value'], $property);
 
-        match ($operator) {
-            'equals' => $query->where($query->qualifyColumn($property), $dbValue),
-            'notEquals' => $query->whereNot($query->qualifyColumn($property), $dbValue),
+        $matchesTruthy = match ($operator) {
+            'equals' => $isTruthy,
+            'notEquals' => ! $isTruthy,
             default => throw ValidationException::withMessages([$property => "Unsupported operator: {$operator}. Use 'equals' or 'notEquals'."]),
         };
-    }
 
-    private function toDbValue(mixed $value, string $property): int
-    {
-        if ($value === true || $value === 1 || $value === '1' || $value === 'true') {
-            return 1;
+        $column = $query->qualifyColumn($property);
+
+        if ($matchesTruthy) {
+            $query->where($column, '>', 0);
+
+            return;
         }
-        if ($value === false || $value === 0 || $value === '0' || $value === 'false') {
-            return 0;
-        }
-        throw ValidationException::withMessages([$property => "Invalid value: {$value}. Valid values are: true, false."]);
+
+        $query->where(function (Builder $query) use ($column): void {
+            $query->where($column, 0)->orWhereNull($column);
+        });
     }
 }

--- a/src/Query/Filters/FilterValue.php
+++ b/src/Query/Filters/FilterValue.php
@@ -10,10 +10,13 @@ use Illuminate\Validation\ValidationException;
  * Filters that build their own predicate - including relation based ones outside
  * this package - should reuse these helpers instead of re-implementing the
  * accepted value spellings and their error messages.
+ *
+ * The `$filterName` argument keys the thrown `ValidationException`, so pass the
+ * API facing filter name rather than the internal column a query is built on.
  */
 final class FilterValue
 {
-    public static function toBool(mixed $value, string $property): bool
+    public static function toBool(mixed $value, string $filterName): bool
     {
         if ($value === true || $value === 1 || $value === '1' || $value === 'true') {
             return true;
@@ -24,27 +27,27 @@ final class FilterValue
         }
 
         throw ValidationException::withMessages([
-            $property => 'Invalid value: '.self::printable($value).'. Valid values are: true, false.',
+            $filterName => 'Invalid value: '.self::printable($value).'. Valid values are: true, false.',
         ]);
     }
 
     /**
      * @return non-empty-list<int>
      */
-    public static function toIds(mixed $value, string $property): array
+    public static function toIds(mixed $value, string $filterName): array
     {
         $ids = array_values(Arr::wrap($value));
 
         if ($ids === []) {
             throw ValidationException::withMessages([
-                $property => 'Invalid value: []. Expected one or more numeric ids.',
+                $filterName => 'Invalid value: []. Expected one or more numeric ids.',
             ]);
         }
 
-        return array_map(static function (mixed $id) use ($property): int {
+        return array_map(static function (mixed $id) use ($filterName): int {
             if (! is_numeric($id)) {
                 throw ValidationException::withMessages([
-                    $property => 'Invalid value: '.self::printable($id).'. Expected one or more numeric ids.',
+                    $filterName => 'Invalid value: '.self::printable($id).'. Expected one or more numeric ids.',
                 ]);
             }
 

--- a/src/Query/Filters/FilterValue.php
+++ b/src/Query/Filters/FilterValue.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+namespace Xentral\LaravelApi\Query\Filters;
+
+use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Coerces and validates raw filter input before it reaches a query.
+ *
+ * Filters that build their own predicate - including relation based ones outside
+ * this package - should reuse these helpers instead of re-implementing the
+ * accepted value spellings and their error messages.
+ */
+final class FilterValue
+{
+    public static function toBool(mixed $value, string $property): bool
+    {
+        if ($value === true || $value === 1 || $value === '1' || $value === 'true') {
+            return true;
+        }
+
+        if ($value === false || $value === 0 || $value === '0' || $value === 'false') {
+            return false;
+        }
+
+        throw ValidationException::withMessages([
+            $property => 'Invalid value: '.self::printable($value).'. Valid values are: true, false.',
+        ]);
+    }
+
+    /**
+     * @return non-empty-list<int>
+     */
+    public static function toIds(mixed $value, string $property): array
+    {
+        $ids = array_values(Arr::wrap($value));
+
+        if ($ids === []) {
+            throw ValidationException::withMessages([
+                $property => 'Invalid value: []. Expected one or more numeric ids.',
+            ]);
+        }
+
+        return array_map(static function (mixed $id) use ($property): int {
+            if (! is_numeric($id)) {
+                throw ValidationException::withMessages([
+                    $property => 'Invalid value: '.self::printable($id).'. Expected one or more numeric ids.',
+                ]);
+            }
+
+            return (int) $id;
+        }, $ids);
+    }
+
+    private static function printable(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return is_scalar($value) ? (string) $value : gettype($value);
+    }
+}

--- a/src/Query/Filters/HasRepeatedFilterKeys.php
+++ b/src/Query/Filters/HasRepeatedFilterKeys.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+namespace Xentral\LaravelApi\Query\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Filters\Filter;
+
+/**
+ * Applies a filter key that appeared more than once in the request.
+ *
+ * QueryBuilderRequest collapses a repeated key into a list of {operator, value}
+ * entries, so each entry has to be applied in turn - conjunctively, since every
+ * entry narrows the same query.
+ *
+ * @phpstan-require-implements Filter
+ */
+trait HasRepeatedFilterKeys
+{
+    protected function applyRepeatedFilters(Builder $query, mixed $value, string $property): bool
+    {
+        if (! isset($value[0]) || ! is_array($value[0])) {
+            return false;
+        }
+
+        foreach ($value as $filter) {
+            $this->__invoke($query, $filter, $property);
+        }
+
+        return true;
+    }
+}

--- a/src/Query/Filters/IdCallbackFilter.php
+++ b/src/Query/Filters/IdCallbackFilter.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+namespace Xentral\LaravelApi\Query\Filters;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Validation\ValidationException;
+use Spatie\QueryBuilder\Filters\Filter;
+
+/**
+ * Filters by id where the target is a predicate rather than a column: a relation,
+ * a pivot, or a legacy column that encodes the id inside another value.
+ *
+ * The callback is handed a non-empty list of ids and constrains the query to rows
+ * matching any of them. Operator handling, id validation and negation stay in this
+ * filter, so a caller only writes the positive membership predicate.
+ */
+class IdCallbackFilter implements Filter
+{
+    use HasRepeatedFilterKeys;
+
+    private const SUPPORTED_OPERATORS = [
+        FilterOperator::EQUALS,
+        FilterOperator::NOT_EQUALS,
+        FilterOperator::IN,
+        FilterOperator::NOT_IN,
+    ];
+
+    /**
+     * @param  Closure(Builder, non-empty-list<int>): void  $apply
+     */
+    public function __construct(
+        private readonly Closure $apply,
+        private readonly IdFilterTarget $target,
+    ) {}
+
+    public function __invoke(Builder $query, mixed $value, string $property): void
+    {
+        if ($this->applyRepeatedFilters($query, $value, $property)) {
+            return;
+        }
+
+        $operator = $this->toOperator($value['operator'] ?? 'equals', $property);
+        $ids = FilterValue::toIds($value['value'] ?? null, $property);
+
+        if ($operator === FilterOperator::NOT_EQUALS || $operator === FilterOperator::NOT_IN) {
+            $query->whereNot(function (Builder $query) use ($ids): void {
+                ($this->apply)($query, $ids);
+            });
+
+            return;
+        }
+
+        if ($operator === FilterOperator::EQUALS && $this->target === IdFilterTarget::Relation && count($ids) > 1) {
+            foreach ($ids as $id) {
+                ($this->apply)($query, [$id]);
+            }
+
+            return;
+        }
+
+        ($this->apply)($query, $ids);
+    }
+
+    private function toOperator(mixed $operator, string $property): FilterOperator
+    {
+        $parsed = is_string($operator) ? FilterOperator::tryFrom($operator) : null;
+
+        if ($parsed === null || ! in_array($parsed, self::SUPPORTED_OPERATORS, true)) {
+            throw ValidationException::withMessages([
+                $property => "Unsupported operator: {$this->printableOperator($operator)}. Use 'equals', 'notEquals', 'in' or 'notIn'.",
+            ]);
+        }
+
+        return $parsed;
+    }
+
+    private function printableOperator(mixed $operator): string
+    {
+        return is_scalar($operator) ? (string) $operator : gettype($operator);
+    }
+}

--- a/src/Query/Filters/IdCallbackFilter.php
+++ b/src/Query/Filters/IdCallbackFilter.php
@@ -29,7 +29,10 @@ class IdCallbackFilter implements Filter
     ];
 
     /**
-     * @param  Closure(Builder, non-empty-list<int>): void  $apply
+     * The return value of `$apply` is discarded, so a single expression arrow function
+     * returning the builder is as valid as a block closure returning nothing.
+     *
+     * @param  Closure(Builder, non-empty-list<int>): mixed  $apply
      */
     public function __construct(
         private readonly Closure $apply,

--- a/src/Query/Filters/IdCallbackFilter.php
+++ b/src/Query/Filters/IdCallbackFilter.php
@@ -13,6 +13,9 @@ use Spatie\QueryBuilder\Filters\Filter;
  * The callback is handed a non-empty list of ids and constrains the query to rows
  * matching any of them. Operator handling, id validation and negation stay in this
  * filter, so a caller only writes the positive membership predicate.
+ *
+ * Each invocation of the callback is wrapped in its own nested where, so a predicate
+ * using `orWhere` cannot widen the query it is applied to.
  */
 class IdCallbackFilter implements Filter
 {
@@ -52,13 +55,23 @@ class IdCallbackFilter implements Filter
 
         if ($operator === FilterOperator::EQUALS && $this->target === IdFilterTarget::Relation && count($ids) > 1) {
             foreach ($ids as $id) {
-                ($this->apply)($query, [$id]);
+                $this->applyGrouped($query, [$id]);
             }
 
             return;
         }
 
-        ($this->apply)($query, $ids);
+        $this->applyGrouped($query, $ids);
+    }
+
+    /**
+     * @param  non-empty-list<int>  $ids
+     */
+    private function applyGrouped(Builder $query, array $ids): void
+    {
+        $query->where(function (Builder $query) use ($ids): void {
+            ($this->apply)($query, $ids);
+        });
     }
 
     private function toOperator(mixed $operator, string $property): FilterOperator

--- a/src/Query/Filters/IdFilterTarget.php
+++ b/src/Query/Filters/IdFilterTarget.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+namespace Xentral\LaravelApi\Query\Filters;
+
+/**
+ * What an id filter built from a callback points at.
+ *
+ * A relation can hold many rows per record, so `equals` with several ids means
+ * "all of them" there. A column holds one value per record, where the same
+ * reading would be unsatisfiable, so `equals` stays "any of them".
+ */
+enum IdFilterTarget: string
+{
+    case Relation = 'relation';
+    case Column = 'column';
+}

--- a/src/Query/Filters/QueryFilter.php
+++ b/src/Query/Filters/QueryFilter.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Xentral\LaravelApi\Query\Filters;
 
+use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\AllowedFilter;
 
 class QueryFilter
@@ -24,6 +25,23 @@ class QueryFilter
                 FilterOperator::IS_NOT_NULL,
             ]),
             $internalName,
+        );
+    }
+
+    /**
+     * Filters by id where the target is a predicate rather than a column.
+     *
+     * `$apply` receives the query and a non-empty list of ints, and constrains the
+     * query to rows matching any of those ids. Operators, validation and negation
+     * are handled by the filter.
+     *
+     * @param  callable(Builder, non-empty-list<int>): void  $apply
+     */
+    public static function identifierCallback(string $name, callable $apply, IdFilterTarget $target): AllowedFilter
+    {
+        return AllowedFilter::custom(
+            $name,
+            new IdCallbackFilter(\Closure::fromCallable($apply), $target),
         );
     }
 

--- a/src/Query/Filters/QueryFilter.php
+++ b/src/Query/Filters/QueryFilter.php
@@ -106,7 +106,7 @@ class QueryFilter
 
     public static function booleanInteger(string $name, ?string $internalName = null): AllowedFilter
     {
-        return AllowedFilter::custom($name, new BooleanIntegerFilter, $internalName);
+        return AllowedFilter::custom($name, new BooleanIntegerFilter($name), $internalName);
     }
 
     public function make(

--- a/src/Query/Filters/QueryFilter.php
+++ b/src/Query/Filters/QueryFilter.php
@@ -35,7 +35,7 @@ class QueryFilter
      * query to rows matching any of those ids. Operators, validation and negation
      * are handled by the filter.
      *
-     * @param  callable(Builder, non-empty-list<int>): void  $apply
+     * @param  callable(Builder, non-empty-list<int>): mixed  $apply
      */
     public static function identifierCallback(string $name, callable $apply, IdFilterTarget $target): AllowedFilter
     {

--- a/src/Query/Filters/StringOperatorFilter.php
+++ b/src/Query/Filters/StringOperatorFilter.php
@@ -9,6 +9,8 @@ use Spatie\QueryBuilder\Filters\FiltersExact;
 
 class StringOperatorFilter extends FiltersExact
 {
+    use HasRepeatedFilterKeys;
+
     private const NEGATIVE_TO_POSITIVE_MAP = [
         'notIn' => 'in',
         'notEquals' => 'equals',
@@ -19,11 +21,7 @@ class StringOperatorFilter extends FiltersExact
 
     public function __invoke(Builder $query, mixed $value, string $property)
     {
-        if (isset($value[0]) && is_array($value[0])) {
-            foreach ($value as $filter) {
-                $this->__invoke($query, $filter, $property);
-            }
-
+        if ($this->applyRepeatedFilters($query, $value, $property)) {
             return;
         }
 

--- a/tests/Feature/Http/Endpoints/Customers/ListCustomersTest.php
+++ b/tests/Feature/Http/Endpoints/Customers/ListCustomersTest.php
@@ -447,6 +447,37 @@ describe('Customer BooleanInteger Filters', function () {
         $response->assertStatus(422);
         $response->assertJsonValidationErrors(['is_verified']);
     });
+
+    it('treats a flag value above one as true, matching what the payload shows', function () {
+        Customer::factory()->create(['is_verified' => 2]);
+        Customer::factory()->count(2)->unverified()->create();
+
+        $query = buildFilterQuery([[
+            'key' => 'is_verified',
+            'op' => 'equals',
+            'value' => true,
+        ]]);
+        $response = $this->getJson("/api/v1/customers?{$query}");
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+    });
+
+    it('counts a null flag as false', function () {
+        Customer::factory()->count(2)->create(['is_archived' => null]);
+        Customer::factory()->notArchived()->create();
+        Customer::factory()->archived()->create();
+
+        $query = buildFilterQuery([[
+            'key' => 'is_archived',
+            'op' => 'equals',
+            'value' => false,
+        ]]);
+        $response = $this->getJson("/api/v1/customers?{$query}");
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+    });
 });
 
 describe('Customer Multiple Filter Combinations', function () {

--- a/tests/Feature/Http/Endpoints/Invoices/ListInvoicesTest.php
+++ b/tests/Feature/Http/Endpoints/Invoices/ListInvoicesTest.php
@@ -1485,3 +1485,94 @@ describe('Invoice Multiple Filters on Same Property', function () {
         $response->assertJsonCount(1, 'data');
     });
 });
+
+describe('Invoice Callback Id Filter', function () {
+    it('requires all line item ids to match for equals', function () {
+        $withBoth = Invoice::factory()->create();
+        $bothIds = LineItem::factory()->count(2)->for($withBoth)->create()->pluck('id')->all();
+
+        $withOne = Invoice::factory()->create();
+        LineItem::factory()->for($withOne)->create();
+
+        $query = buildFilterQuery([[
+            'key' => 'lineItem.id',
+            'op' => 'equals',
+            'value' => $bothIds,
+        ]]);
+
+        $response = $this->getJson("/api/v1/invoices?{$query}");
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $withBoth->id);
+    });
+
+    it('matches any line item id for in', function () {
+        $first = Invoice::factory()->create();
+        $second = Invoice::factory()->create();
+        $ids = [
+            LineItem::factory()->for($first)->create()->id,
+            LineItem::factory()->for($second)->create()->id,
+        ];
+
+        $other = Invoice::factory()->create();
+        LineItem::factory()->for($other)->create();
+
+        $query = buildFilterQuery([[
+            'key' => 'lineItem.id',
+            'op' => 'in',
+            'value' => $ids,
+        ]]);
+
+        $response = $this->getJson("/api/v1/invoices?{$query}");
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+    });
+
+    it('excludes the listed line item ids for notIn', function () {
+        $excluded = Invoice::factory()->create();
+        $excludedId = LineItem::factory()->for($excluded)->create()->id;
+
+        $kept = Invoice::factory()->create();
+        LineItem::factory()->for($kept)->create();
+
+        $query = buildFilterQuery([[
+            'key' => 'lineItem.id',
+            'op' => 'notIn',
+            'value' => [$excludedId],
+        ]]);
+
+        $response = $this->getJson("/api/v1/invoices?{$query}");
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $kept->id);
+    });
+
+    it('rejects an empty id list instead of letting notIn return everything', function () {
+        $invoice = Invoice::factory()->create();
+        LineItem::factory()->for($invoice)->create();
+
+        $query = buildFilterQuery([[
+            'key' => 'lineItem.id',
+            'op' => 'notIn',
+            'value' => [],
+        ]]);
+
+        $response = $this->getJson("/api/v1/invoices?{$query}");
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['lineItem.id']);
+    });
+
+    it('rejects a non-numeric id', function () {
+        Invoice::factory()->create();
+
+        $query = buildFilterQuery([[
+            'key' => 'lineItem.id',
+            'op' => 'in',
+            'value' => ['abc'],
+        ]]);
+
+        $response = $this->getJson("/api/v1/invoices?{$query}");
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['lineItem.id']);
+    });
+});

--- a/tests/Unit/Query/Filters/BooleanIntegerFilterTest.php
+++ b/tests/Unit/Query/Filters/BooleanIntegerFilterTest.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Validation\ValidationException;
+use Workbench\App\Models\Customer;
+use Xentral\LaravelApi\Query\Filters\BooleanIntegerFilter;
+
+function applyBooleanIntegerFilter(mixed $value, string $property = 'is_verified'): int
+{
+    $filter = new BooleanIntegerFilter;
+    $query = Customer::query();
+    $filter($query, $value, $property);
+
+    return $query->count();
+}
+
+describe('BooleanIntegerFilter truthy semantics', function () {
+    it('matches every value greater than zero for true, not just one', function () {
+        Customer::factory()->create(['is_verified' => 2]);
+        Customer::factory()->create(['is_verified' => 1]);
+        Customer::factory()->create(['is_verified' => 0]);
+
+        expect(applyBooleanIntegerFilter(['operator' => 'equals', 'value' => true]))->toBe(2);
+    });
+
+    it('does not match a value greater than one for false', function () {
+        Customer::factory()->create(['is_verified' => 2]);
+        Customer::factory()->create(['is_verified' => 0]);
+
+        expect(applyBooleanIntegerFilter(['operator' => 'equals', 'value' => false]))->toBe(1);
+    });
+
+    it('matches null for false, mirroring what the (bool) cast shows in the payload', function () {
+        Customer::factory()->create(['is_archived' => null]);
+        Customer::factory()->create(['is_archived' => 0]);
+        Customer::factory()->create(['is_archived' => 1]);
+
+        expect(applyBooleanIntegerFilter(['operator' => 'equals', 'value' => false], 'is_archived'))->toBe(2);
+    });
+
+    it('does not match null for true', function () {
+        Customer::factory()->create(['is_archived' => null]);
+        Customer::factory()->create(['is_archived' => 3]);
+
+        expect(applyBooleanIntegerFilter(['operator' => 'equals', 'value' => true], 'is_archived'))->toBe(1);
+    });
+
+    it('inverts notEquals true to the falsy predicate, including null', function () {
+        Customer::factory()->create(['is_archived' => null]);
+        Customer::factory()->create(['is_archived' => 0]);
+        Customer::factory()->create(['is_archived' => 2]);
+
+        expect(applyBooleanIntegerFilter(['operator' => 'notEquals', 'value' => true], 'is_archived'))->toBe(2);
+    });
+
+    it('inverts notEquals false to the truthy predicate', function () {
+        Customer::factory()->create(['is_archived' => null]);
+        Customer::factory()->create(['is_archived' => 0]);
+        Customer::factory()->create(['is_archived' => 2]);
+
+        expect(applyBooleanIntegerFilter(['operator' => 'notEquals', 'value' => false], 'is_archived'))->toBe(1);
+    });
+
+    it('keeps the null branch grouped so it cannot widen a surrounding constraint', function () {
+        Customer::factory()->create(['country' => 'DE', 'is_archived' => null]);
+        Customer::factory()->create(['country' => 'AT', 'is_archived' => null]);
+
+        $filter = new BooleanIntegerFilter;
+        $query = Customer::query()->where('country', 'DE');
+        $filter($query, ['operator' => 'equals', 'value' => false], 'is_archived');
+
+        expect($query->count())->toBe(1);
+    });
+});
+
+describe('BooleanIntegerFilter value coercion', function () {
+    it('still accepts every documented spelling', function (mixed $value, int $expected) {
+        Customer::factory()->create(['is_verified' => 2]);
+        Customer::factory()->create(['is_verified' => 0]);
+
+        expect(applyBooleanIntegerFilter(['operator' => 'equals', 'value' => $value]))->toBe($expected);
+    })->with([
+        [true, 1],
+        [1, 1],
+        ['1', 1],
+        ['true', 1],
+        [false, 1],
+        [0, 1],
+        ['0', 1],
+        ['false', 1],
+    ]);
+
+    it('keeps the documented message for an invalid value', function () {
+        try {
+            applyBooleanIntegerFilter(['operator' => 'equals', 'value' => 'maybe']);
+        } catch (ValidationException $e) {
+            expect($e->errors()['is_verified'][0])->toBe('Invalid value: maybe. Valid values are: true, false.');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('keeps the documented message for an unsupported operator', function () {
+        try {
+            applyBooleanIntegerFilter(['operator' => 'in', 'value' => true]);
+        } catch (ValidationException $e) {
+            expect($e->errors()['is_verified'][0])->toBe("Unsupported operator: in. Use 'equals' or 'notEquals'.");
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+});
+
+describe('BooleanIntegerFilter repeated filter keys', function () {
+    it('applies every entry of a repeated key conjunctively', function () {
+        Customer::factory()->create(['is_verified' => 2]);
+        Customer::factory()->create(['is_verified' => 0]);
+
+        $contradicting = [
+            ['operator' => 'equals', 'value' => true],
+            ['operator' => 'equals', 'value' => false],
+        ];
+
+        expect(applyBooleanIntegerFilter($contradicting))->toBe(0);
+    });
+
+    it('applies a repeated key that agrees with itself', function () {
+        Customer::factory()->create(['is_verified' => 2]);
+        Customer::factory()->create(['is_verified' => 0]);
+
+        $agreeing = [
+            ['operator' => 'equals', 'value' => true],
+            ['operator' => 'notEquals', 'value' => false],
+        ];
+
+        expect(applyBooleanIntegerFilter($agreeing))->toBe(1);
+    });
+});

--- a/tests/Unit/Query/Filters/BooleanIntegerFilterTest.php
+++ b/tests/Unit/Query/Filters/BooleanIntegerFilterTest.php
@@ -190,3 +190,20 @@ describe('BooleanIntegerFilter repeated filter keys', function () {
         expect(applyBooleanIntegerFilter($agreeing))->toBe(1);
     });
 });
+
+describe('BooleanIntegerFilter missing value key', function () {
+    it('rejects a filter without a value instead of raising an undefined key warning', function () {
+        $filter = new BooleanIntegerFilter('isVerified');
+        $query = Customer::query();
+
+        try {
+            $filter($query, ['operator' => 'equals'], 'is_verified');
+        } catch (ValidationException $e) {
+            expect($e->errors()['isVerified'][0])->toBe('Invalid value: NULL. Valid values are: true, false.');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+});

--- a/tests/Unit/Query/Filters/BooleanIntegerFilterTest.php
+++ b/tests/Unit/Query/Filters/BooleanIntegerFilterTest.php
@@ -3,10 +3,11 @@
 use Illuminate\Validation\ValidationException;
 use Workbench\App\Models\Customer;
 use Xentral\LaravelApi\Query\Filters\BooleanIntegerFilter;
+use Xentral\LaravelApi\Query\Filters\QueryFilter;
 
 function applyBooleanIntegerFilter(mixed $value, string $property = 'is_verified'): int
 {
-    $filter = new BooleanIntegerFilter;
+    $filter = new BooleanIntegerFilter($property);
     $query = Customer::query();
     $filter($query, $value, $property);
 
@@ -64,7 +65,7 @@ describe('BooleanIntegerFilter truthy semantics', function () {
         Customer::factory()->create(['country' => 'DE', 'is_archived' => null]);
         Customer::factory()->create(['country' => 'AT', 'is_archived' => null]);
 
-        $filter = new BooleanIntegerFilter;
+        $filter = new BooleanIntegerFilter('is_archived');
         $query = Customer::query()->where('country', 'DE');
         $filter($query, ['operator' => 'equals', 'value' => false], 'is_archived');
 
@@ -106,6 +107,56 @@ describe('BooleanIntegerFilter value coercion', function () {
             applyBooleanIntegerFilter(['operator' => 'in', 'value' => true]);
         } catch (ValidationException $e) {
             expect($e->errors()['is_verified'][0])->toBe("Unsupported operator: in. Use 'equals' or 'notEquals'.");
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+});
+
+describe('BooleanIntegerFilter error naming', function () {
+    it('keys an invalid value error by the API filter name, not the internal column', function () {
+        $filter = new BooleanIntegerFilter('isVariant');
+        $query = Customer::query();
+
+        try {
+            $filter($query, ['operator' => 'equals', 'value' => 'maybe'], 'variante');
+        } catch (ValidationException $e) {
+            expect($e->errors())->toHaveKey('isVariant')
+                ->and($e->errors())->not->toHaveKey('variante');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('keys an unsupported operator error by the API filter name, not the internal column', function () {
+        $filter = new BooleanIntegerFilter('isVariant');
+        $query = Customer::query();
+
+        try {
+            $filter($query, ['operator' => 'in', 'value' => true], 'variante');
+        } catch (ValidationException $e) {
+            expect($e->errors())->toHaveKey('isVariant')
+                ->and($e->errors())->not->toHaveKey('variante');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('keys errors by the API name when wired through QueryFilter::booleanInteger', function () {
+        $filter = QueryFilter::booleanInteger('isVariant', 'variante')->getFilterClass();
+        $query = Customer::query();
+
+        try {
+            $filter($query, ['operator' => 'equals', 'value' => 'maybe'], 'variante');
+        } catch (ValidationException $e) {
+            expect($e->errors())->toHaveKey('isVariant')
+                ->and($e->errors())->not->toHaveKey('variante');
 
             return;
         }

--- a/tests/Unit/Query/Filters/FilterValueTest.php
+++ b/tests/Unit/Query/Filters/FilterValueTest.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Validation\ValidationException;
+use Xentral\LaravelApi\Query\Filters\FilterValue;
+
+describe('FilterValue::toBool', function () {
+    it('coerces every accepted truthy spelling', function (mixed $value) {
+        expect(FilterValue::toBool($value, 'isActive'))->toBeTrue();
+    })->with([true, 1, '1', 'true']);
+
+    it('coerces every accepted falsy spelling', function (mixed $value) {
+        expect(FilterValue::toBool($value, 'isActive'))->toBeFalse();
+    })->with([false, 0, '0', 'false']);
+
+    it('rejects any other value with the documented message', function () {
+        try {
+            FilterValue::toBool('yes', 'isActive');
+        } catch (ValidationException $e) {
+            expect($e->errors()['isActive'][0])->toBe('Invalid value: yes. Valid values are: true, false.');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('prints a non-scalar value as its type instead of interpolating it', function () {
+        try {
+            FilterValue::toBool(['true'], 'isActive');
+        } catch (ValidationException $e) {
+            expect($e->errors()['isActive'][0])->toBe('Invalid value: array. Valid values are: true, false.');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+});
+
+describe('FilterValue::toIds', function () {
+    it('wraps a single numeric value into a list of ints', function () {
+        expect(FilterValue::toIds('7', 'categories.id'))->toBe([7]);
+    });
+
+    it('casts a numeric list to ints', function () {
+        expect(FilterValue::toIds(['3', 4], 'categories.id'))->toBe([3, 4]);
+    });
+
+    it('reindexes a sparse list so the callback always receives a list', function () {
+        expect(FilterValue::toIds([1 => '3', 5 => '4'], 'categories.id'))->toBe([3, 4]);
+    });
+
+    it('rejects a non-numeric id with the documented message', function () {
+        try {
+            FilterValue::toIds(['3', 'abc'], 'categories.id');
+        } catch (ValidationException $e) {
+            expect($e->errors()['categories.id'][0])->toBe('Invalid value: abc. Expected one or more numeric ids.');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('prints a non-scalar id as its type instead of interpolating it', function () {
+        try {
+            FilterValue::toIds([[1]], 'categories.id');
+        } catch (ValidationException $e) {
+            expect($e->errors()['categories.id'][0])->toBe('Invalid value: array. Expected one or more numeric ids.');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('rejects an empty list, so no caller can ever receive zero ids', function () {
+        try {
+            FilterValue::toIds([], 'categories.id');
+        } catch (ValidationException $e) {
+            expect($e->errors()['categories.id'][0])->toBe('Invalid value: []. Expected one or more numeric ids.');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('rejects null the same way, independently of spatie normalising an empty list to null', function () {
+        try {
+            FilterValue::toIds(null, 'categories.id');
+        } catch (ValidationException $e) {
+            expect($e->errors()['categories.id'][0])->toBe('Invalid value: []. Expected one or more numeric ids.');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+});

--- a/tests/Unit/Query/Filters/IdCallbackFilterTest.php
+++ b/tests/Unit/Query/Filters/IdCallbackFilterTest.php
@@ -1,0 +1,213 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Validation\ValidationException;
+use Workbench\App\Models\Customer;
+use Workbench\App\Models\Invoice;
+use Workbench\App\Models\LineItem;
+use Xentral\LaravelApi\Query\Filters\IdCallbackFilter;
+use Xentral\LaravelApi\Query\Filters\IdFilterTarget;
+
+function lineItemsIdFilter(?ArrayObject $received = null): IdCallbackFilter
+{
+    return new IdCallbackFilter(
+        function (Builder $query, array $ids) use ($received): void {
+            $received?->append($ids);
+            $query->whereHas('lineItems', fn (Builder $lineItems) => $lineItems->whereIn('line_items.id', $ids));
+        },
+        IdFilterTarget::Relation,
+    );
+}
+
+function customerColumnIdFilter(?ArrayObject $received = null): IdCallbackFilter
+{
+    return new IdCallbackFilter(
+        function (Builder $query, array $ids) use ($received): void {
+            $received?->append($ids);
+            $query->whereIn('invoices.customer_id', $ids);
+        },
+        IdFilterTarget::Column,
+    );
+}
+
+function invoiceWithLineItems(int $count): array
+{
+    $invoice = Invoice::factory()->create();
+    $lineItems = LineItem::factory()->count($count)->for($invoice)->create();
+
+    return [$invoice, $lineItems->pluck('id')->all()];
+}
+
+describe('IdCallbackFilter on a relation target', function () {
+    it('requires all ids to match for equals with a list', function () {
+        [$withBoth, $bothIds] = invoiceWithLineItems(2);
+        $withFirstOnly = Invoice::factory()->create();
+        LineItem::factory()->for($withFirstOnly)->create();
+
+        $query = Invoice::query();
+        lineItemsIdFilter()($query, ['operator' => 'equals', 'value' => $bothIds], 'lineItem.id');
+
+        expect($query->pluck('id')->all())->toBe([$withBoth->id]);
+    });
+
+    it('invokes the callback once per id for equals with a list', function () {
+        [, $bothIds] = invoiceWithLineItems(2);
+        $received = new ArrayObject;
+
+        $query = Invoice::query();
+        lineItemsIdFilter($received)($query, ['operator' => 'equals', 'value' => $bothIds], 'lineItem.id');
+
+        expect($received->getArrayCopy())->toBe([[$bothIds[0]], [$bothIds[1]]]);
+    });
+
+    it('matches any id for in', function () {
+        [$first, $firstIds] = invoiceWithLineItems(1);
+        [$second, $secondIds] = invoiceWithLineItems(1);
+        invoiceWithLineItems(1);
+
+        $query = Invoice::query();
+        lineItemsIdFilter()($query, ['operator' => 'in', 'value' => [$firstIds[0], $secondIds[0]]], 'lineItem.id');
+
+        expect($query->pluck('id')->all())->toEqualCanonicalizing([$first->id, $second->id]);
+    });
+
+    it('invokes the callback once with every id for in', function () {
+        [, $bothIds] = invoiceWithLineItems(2);
+        $received = new ArrayObject;
+
+        $query = Invoice::query();
+        lineItemsIdFilter($received)($query, ['operator' => 'in', 'value' => $bothIds], 'lineItem.id');
+
+        expect($received->getArrayCopy())->toBe([$bothIds]);
+    });
+
+    it('excludes every listed id for notIn', function () {
+        [, $excludedIds] = invoiceWithLineItems(2);
+        [$kept] = invoiceWithLineItems(1);
+
+        $query = Invoice::query();
+        lineItemsIdFilter()($query, ['operator' => 'notIn', 'value' => $excludedIds], 'lineItem.id');
+
+        expect($query->pluck('id')->all())->toBe([$kept->id]);
+    });
+
+    it('treats notEquals with a list like notIn, matching none of them', function () {
+        [, $excludedIds] = invoiceWithLineItems(2);
+        [$kept] = invoiceWithLineItems(1);
+
+        $query = Invoice::query();
+        lineItemsIdFilter()($query, ['operator' => 'notEquals', 'value' => $excludedIds], 'lineItem.id');
+
+        expect($query->pluck('id')->all())->toBe([$kept->id]);
+    });
+});
+
+describe('IdCallbackFilter on a column target', function () {
+    it('keeps equals with a list satisfiable instead of anding it into nothing', function () {
+        $first = Customer::factory()->create();
+        $second = Customer::factory()->create();
+        Invoice::factory()->create(['customer_id' => $first->id]);
+        Invoice::factory()->create(['customer_id' => $second->id]);
+        Invoice::factory()->create();
+
+        $received = new ArrayObject;
+        $query = Invoice::query();
+        customerColumnIdFilter($received)($query, ['operator' => 'equals', 'value' => [$first->id, $second->id]], 'customer.id');
+
+        expect($query->count())->toBe(2)
+            ->and($received->getArrayCopy())->toBe([[$first->id, $second->id]]);
+    });
+
+    it('excludes every listed id for notIn on a plain column', function () {
+        $excluded = Customer::factory()->create();
+        $kept = Customer::factory()->create();
+        Invoice::factory()->create(['customer_id' => $excluded->id]);
+        $keptInvoice = Invoice::factory()->create(['customer_id' => $kept->id]);
+
+        $query = Invoice::query();
+        customerColumnIdFilter()($query, ['operator' => 'notIn', 'value' => [$excluded->id]], 'customer.id');
+
+        expect($query->pluck('id')->all())->toBe([$keptInvoice->id]);
+    });
+});
+
+describe('IdCallbackFilter validation', function () {
+    it('rejects an unsupported operator with the documented message', function () {
+        try {
+            lineItemsIdFilter()(Invoice::query(), ['operator' => 'contains', 'value' => [1]], 'lineItem.id');
+        } catch (ValidationException $e) {
+            expect($e->errors()['lineItem.id'][0])->toBe("Unsupported operator: contains. Use 'equals', 'notEquals', 'in' or 'notIn'.");
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('rejects a non-numeric id', function () {
+        try {
+            lineItemsIdFilter()(Invoice::query(), ['operator' => 'in', 'value' => ['1', 'abc']], 'lineItem.id');
+        } catch (ValidationException $e) {
+            expect($e->errors()['lineItem.id'][0])->toBe('Invalid value: abc. Expected one or more numeric ids.');
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('rejects an empty id list instead of letting notIn match everything', function () {
+        $received = new ArrayObject;
+
+        try {
+            lineItemsIdFilter($received)(Invoice::query(), ['operator' => 'notIn', 'value' => []], 'lineItem.id');
+        } catch (ValidationException $e) {
+            expect($e->errors()['lineItem.id'][0])->toBe('Invalid value: []. Expected one or more numeric ids.')
+                ->and($received->count())->toBe(0);
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('rejects a null value the same way, without relying on spatie normalising an empty list', function () {
+        $received = new ArrayObject;
+
+        try {
+            lineItemsIdFilter($received)(Invoice::query(), ['operator' => 'notIn', 'value' => null], 'lineItem.id');
+        } catch (ValidationException $e) {
+            expect($e->errors()['lineItem.id'][0])->toBe('Invalid value: []. Expected one or more numeric ids.')
+                ->and($received->count())->toBe(0);
+
+            return;
+        }
+
+        $this->fail('Expected a ValidationException');
+    });
+
+    it('hands the callback ints even when the request carried numeric strings', function () {
+        [, $ids] = invoiceWithLineItems(2);
+        $received = new ArrayObject;
+
+        $query = Invoice::query();
+        lineItemsIdFilter($received)($query, ['operator' => 'in', 'value' => array_map(strval(...), $ids)], 'lineItem.id');
+
+        expect($received->getArrayCopy())->toBe([$ids]);
+    });
+});
+
+describe('IdCallbackFilter repeated filter keys', function () {
+    it('applies every entry of a repeated key conjunctively', function () {
+        [$withBoth, $bothIds] = invoiceWithLineItems(2);
+        invoiceWithLineItems(1);
+
+        $query = Invoice::query();
+        lineItemsIdFilter()($query, [
+            ['operator' => 'in', 'value' => [$bothIds[0]]],
+            ['operator' => 'in', 'value' => [$bothIds[1]]],
+        ], 'lineItem.id');
+
+        expect($query->pluck('id')->all())->toBe([$withBoth->id]);
+    });
+});

--- a/tests/Unit/Query/Filters/IdCallbackFilterTest.php
+++ b/tests/Unit/Query/Filters/IdCallbackFilterTest.php
@@ -5,8 +5,10 @@ use Illuminate\Validation\ValidationException;
 use Workbench\App\Models\Customer;
 use Workbench\App\Models\Invoice;
 use Workbench\App\Models\LineItem;
+use Xentral\LaravelApi\Query\Filters\FilterOperator;
 use Xentral\LaravelApi\Query\Filters\IdCallbackFilter;
 use Xentral\LaravelApi\Query\Filters\IdFilterTarget;
+use Xentral\LaravelApi\Query\Filters\StringOperatorFilter;
 
 function lineItemsIdFilter(?ArrayObject $received = null): IdCallbackFilter
 {
@@ -118,6 +120,26 @@ describe('IdCallbackFilter on a column target', function () {
             ->and($received->getArrayCopy())->toBe([[$first->id, $second->id]]);
     });
 
+    it('excludes null rows for notIn, exactly like the column based id filter does', function () {
+        Customer::factory()->create(['is_archived' => 5]);
+        $other = Customer::factory()->create(['is_archived' => 7]);
+        Customer::factory()->create(['is_archived' => null]);
+
+        $filter = new IdCallbackFilter(
+            fn (Builder $query, array $ids) => $query->whereIn('customers.is_archived', $ids),
+            IdFilterTarget::Column,
+        );
+
+        $viaCallback = Customer::query();
+        $filter($viaCallback, ['operator' => 'notIn', 'value' => [5]], 'legacy.id');
+
+        $viaColumn = Customer::query();
+        (new StringOperatorFilter([FilterOperator::NOT_IN]))($viaColumn, ['operator' => 'notIn', 'value' => [5]], 'is_archived');
+
+        expect($viaCallback->pluck('id')->all())->toBe([$other->id])
+            ->and($viaCallback->pluck('id')->all())->toBe($viaColumn->pluck('id')->all());
+    });
+
     it('excludes every listed id for notIn on a plain column', function () {
         $excluded = Customer::factory()->create();
         $kept = Customer::factory()->create();
@@ -128,6 +150,45 @@ describe('IdCallbackFilter on a column target', function () {
         customerColumnIdFilter()($query, ['operator' => 'notIn', 'value' => [$excluded->id]], 'customer.id');
 
         expect($query->pluck('id')->all())->toBe([$keptInvoice->id]);
+    });
+});
+
+describe('IdCallbackFilter predicate grouping', function () {
+    it('keeps a callback using orWhere from widening a surrounding constraint', function () {
+        Invoice::factory()->create(['status' => 'open']);
+        $outOfScope = Invoice::factory()->create(['status' => 'paid']);
+
+        $filter = new IdCallbackFilter(
+            fn (Builder $query, array $ids) => $query
+                ->whereIn('invoices.customer_id', $ids)
+                ->orWhereIn('invoices.id', $ids),
+            IdFilterTarget::Column,
+        );
+
+        $query = Invoice::query()->where('status', 'open');
+        $filter($query, ['operator' => 'in', 'value' => [$outOfScope->id]], 'legacy.id');
+
+        expect($query->pluck('id')->all())->not->toContain($outOfScope->id);
+    });
+
+    it('groups every predicate of an anded equals list as well', function () {
+        Invoice::factory()->create(['status' => 'open']);
+        $outOfScope = Invoice::factory()->create(['status' => 'paid']);
+        $secondOutOfScope = Invoice::factory()->create(['status' => 'paid']);
+
+        $filter = new IdCallbackFilter(
+            fn (Builder $query, array $ids) => $query
+                ->whereIn('invoices.customer_id', $ids)
+                ->orWhereIn('invoices.id', $ids),
+            IdFilterTarget::Relation,
+        );
+
+        $query = Invoice::query()->where('status', 'open');
+        $filter($query, ['operator' => 'equals', 'value' => [$outOfScope->id, $secondOutOfScope->id]], 'legacy.id');
+
+        expect($query->pluck('id')->all())
+            ->not->toContain($outOfScope->id)
+            ->not->toContain($secondOutOfScope->id);
     });
 });
 

--- a/tests/Unit/Query/Filters/QueryFilterTest.php
+++ b/tests/Unit/Query/Filters/QueryFilterTest.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\AllowedFilter;
 use Xentral\LaravelApi\Query\Filters\FilterOperator;
+use Xentral\LaravelApi\Query\Filters\IdCallbackFilter;
+use Xentral\LaravelApi\Query\Filters\IdFilterTarget;
 use Xentral\LaravelApi\Query\Filters\QueryFilter;
 use Xentral\LaravelApi\Query\Filters\StringOperatorFilter;
 
@@ -74,5 +77,31 @@ describe('QueryFilter', function () {
         // When empty array is passed, it should default to all FilterOperator cases
         expect($customFilter)->toBeInstanceOf(StringOperatorFilter::class)
             ->and($customFilter->allowedOperators())->toEqual(FilterOperator::cases());
+    });
+
+    it('can create an id filter from a callback', function () {
+        $result = QueryFilter::identifierCallback(
+            'categories.id',
+            fn (Builder $query, array $ids) => $query->whereIn('typ', $ids),
+            IdFilterTarget::Relation,
+        );
+
+        expect($result)->toBeInstanceOf(AllowedFilter::class)
+            ->and($result->getName())->toBe('categories.id')
+            ->and($result->getFilterClass())->toBeInstanceOf(IdCallbackFilter::class);
+    });
+
+    it('accepts any callable, not only a closure, as the id predicate', function () {
+        $predicate = new class
+        {
+            public function __invoke(Builder $query, array $ids): void
+            {
+                $query->whereIn('typ', $ids);
+            }
+        };
+
+        $result = QueryFilter::identifierCallback('merchandiseGroup.id', $predicate, IdFilterTarget::Column);
+
+        expect($result->getFilterClass())->toBeInstanceOf(IdCallbackFilter::class);
     });
 });

--- a/workbench/app/Http/Controller/CustomerController.php
+++ b/workbench/app/Http/Controller/CustomerController.php
@@ -41,6 +41,7 @@ class CustomerController
                     QueryFilter::string('country'),
                     QueryFilter::boolean('is_active'),
                     QueryFilter::booleanInteger('is_verified'),
+                    QueryFilter::booleanInteger('is_archived'),
                 )
                 ->allowedIncludes(['invoices'])
                 ->apiPaginate()

--- a/workbench/app/Http/Controller/InvoiceController.php
+++ b/workbench/app/Http/Controller/InvoiceController.php
@@ -2,6 +2,7 @@
 
 namespace Workbench\App\Http\Controller;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Http\Response;
@@ -21,6 +22,7 @@ use Xentral\LaravelApi\OpenApi\PaginationType;
 use Xentral\LaravelApi\OpenApi\Responses\PdfMediaType;
 use Xentral\LaravelApi\OpenApi\SearchParameter;
 use Xentral\LaravelApi\Query\DummyInclude;
+use Xentral\LaravelApi\Query\Filters\IdFilterTarget;
 use Xentral\LaravelApi\Query\Filters\QueryFilter;
 use Xentral\LaravelApi\Query\QueryBuilder;
 
@@ -70,6 +72,14 @@ class InvoiceController
                     QueryFilter::number('lineItems.quantity', 'lineItems.quantity'),
                     QueryFilter::number('lineItems.unit_price', 'lineItems.unit_price'),
                     QueryFilter::number('lineItems.total_price', 'lineItems.total_price'),
+                    QueryFilter::identifierCallback(
+                        'lineItem.id',
+                        fn (Builder $query, array $ids) => $query->whereHas(
+                            'lineItems',
+                            fn (Builder $lineItems) => $lineItems->whereIn('line_items.id', $ids),
+                        ),
+                        IdFilterTarget::Relation,
+                    ),
                 )
                 ->allowSearch([
                     'invoice_number',

--- a/workbench/app/Models/Customer.php
+++ b/workbench/app/Models/Customer.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Carbon;
  * @property string $country
  * @property bool $is_active
  * @property int $is_verified
+ * @property int|null $is_archived
  * @property Carbon $updated_at
  * @property Carbon $created_at
  */

--- a/workbench/database/factories/CustomerFactory.php
+++ b/workbench/database/factories/CustomerFactory.php
@@ -48,4 +48,18 @@ class CustomerFactory extends Factory
             'is_verified' => 0,
         ]);
     }
+
+    public function archived(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_archived' => 1,
+        ]);
+    }
+
+    public function notArchived(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_archived' => 0,
+        ]);
+    }
 }

--- a/workbench/database/migrations/2025_09_30_000001_create_customers_table.php
+++ b/workbench/database/migrations/2025_09_30_000001_create_customers_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->string('country');
             $table->boolean('is_active')->default(true);
             $table->integer('is_verified')->default(0);
+            $table->integer('is_archived')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Consolidates three pieces of filter mechanics that consumers had to hand-roll because this package could not express them. Prepares `0.18.0` (behaviour change in item 1).

## 1. `BooleanIntegerFilter`: truthy semantics instead of exact `= 1`

The filter targets legacy integer columns that are semantically boolean, and consumers expose them as `(bool) $row->column`. Resolving to an exact `1` made a row holding `2` render as `true` while being invisible to `filter=true`.

| Filter | SQL |
|---|---|
| `equals true`, `notEquals false` | `column > 0` |
| `equals false`, `notEquals true` | `(column = 0 or column is null)` |

**`false` matches `NULL`.** A `NULL` renders as `false` in the payload, so skipping those rows would contradict what the API returns. This is not only a consistency argument — xentral's legacy query layer already reads `a.variante = 0 OR a.variante IS NULL` for the false side (`SqlProductQuery.php:870`, `SqlProductQueryV2.php:644` and `:869`), and `artikel.variante` is `int DEFAULT NULL`. For that column the change is a legacy-parity fix.

`notEquals` now selects the complementary predicate instead of negating a single value. Previously `notEquals true` matched a row holding `2` while `equals true` did not — the filter contradicted itself on exactly the row that motivated this change.

Value coercion and operator handling are unchanged, including the exact messages.

## 2. `QueryFilter::identifierCallback()` for non-column id targets

```php
QueryFilter::identifierCallback(
    'categories.id',
    fn (Builder $query, array $ids) => $query->whereHas(
        'categories',
        fn (Builder $categories) => $categories->whereIn('product_category.id', $ids),
    ),
    IdFilterTarget::Relation,
);
```

The callback only expresses "match any of these ids". The filter owns the rest:

- operators `equals`, `notEquals`, `in`, `notIn`; anything else is a validation error
- ids validated as numeric, cast to `int`
- the callback is guaranteed a non-empty list. This previously held only by accident, via spatie mapping an empty array to `null` (`AllowedFilter::resolveValueForFiltering()`); without it `notIn` with an empty list matches everything. Locked by a test that calls the filter directly with `[]` and with `null`
- `notEquals` and `notIn` negate the predicate, so both mean "matches none of these ids", mirroring `StringOperatorFilter::withRelationConstraint()`
- `equals` with several ids requires **all** of them on `IdFilterTarget::Relation` and stays "any of them" on `IdFilterTarget::Column`, where anding one column against several values would be unsatisfiable. Declaring the target is mandatory so the distinction cannot be skipped

Pairs with the existing `IdFilter` spec attribute, which already exposes the same four operators — no attribute change needed.

## 3. `FilterValue`: the coercion is public now

`BooleanIntegerFilter::toDbValue()` was private, so relation-based boolean filters had to mirror the accepted spellings by hand. `FilterValue::toBool()` and `FilterValue::toIds()` expose it, and both packaged filters use them. Non-scalar input is printed via `gettype` instead of being interpolated, which also removes an "Array to string conversion" warning the boolean message could trigger.

The duplicated repeated-filter-key recursion moved into `HasRepeatedFilterKeys` and is now covered by tests, which it was not before.

## Verification

- `pest` 460 passed, `phpstan` clean without touching the baseline, `pint` and `rector --dry-run` clean
- `workbench/openapi.yml` unchanged: the new workbench filters are declared on the QueryBuilder layer only
- Linked into xentral (branch `API-790`) via `composer link`, all three affected areas green, then unlinked: `ListProductsTest` 74/74 (same as the unlinked baseline — the brief's "60 tests" is stale, that working tree added tests), sales order traffic lights 55/55, role and permission endpoints 52/52

## Notes

- All 17 consumer call sites hold `0`, `1` or `NULL`, so the truthy change is behaviour-preserving except for the `NULL` fix. `artikel.variante` is nullable, the other flag columns are `NOT NULL`; `matrixprodukt` and `auftrag.is_address_valid` are `tinyint(1)`, not `int`
- A negative value matches neither side although PHP casts it to `true`. Not reachable in xentral — the domain casts these columns to boolean and writes literal `0`/`1` — and documented as such
