### PR TITLE
Allowlist the keys exposed in pagination meta

### DIFF
--- a/src/Http/PaginatedResourceResponse.php
+++ b/src/Http/PaginatedResourceResponse.php
@@ -18,14 +18,22 @@ class PaginatedResourceResponse extends BasePaginatedResourceResponse
         return $this->convertCasing($links);
     }
 
+    /**
+     * Allowlisted so that keys Laravel adds to a paginator's `toArray()` cannot
+     * leak into the documented response surface.
+     */
     protected function meta($paginated): array
     {
-        $meta = Arr::except($paginated, [
-            'data',
-            'first_page_url',
-            'last_page_url',
-            'prev_page_url',
-            'next_page_url',
+        $meta = Arr::only($paginated, [
+            'current_page',
+            'last_page',
+            'from',
+            'to',
+            'path',
+            'per_page',
+            'total',
+            'next_cursor',
+            'prev_cursor',
         ]);
 
         return $this->convertCasing($meta);

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -125,8 +125,8 @@ class QueryBuilder extends \Spatie\QueryBuilder\QueryBuilder
 
         return match ($paginationType) {
             PaginationType::SIMPLE => $this->simplePaginate($perPage, page: $currentPage)->withQueryString(),
-            PaginationType::TABLE => $this->paginate($perPage, page: $currentPage)->withQueryString()->withQueryString(),
-            PaginationType::CURSOR => $this->cursorPaginate($perPage)->withQueryString()->withQueryString(),
+            PaginationType::TABLE => $this->paginate($perPage, page: $currentPage)->withQueryString(),
+            PaginationType::CURSOR => $this->cursorPaginate($perPage)->withQueryString(),
         };
     }
 

--- a/tests/Feature/Http/Endpoints/PaginationTest.php
+++ b/tests/Feature/Http/Endpoints/PaginationTest.php
@@ -487,49 +487,29 @@ describe('Pagination Links with Query String', function () {
 });
 
 describe('Pagination Meta Surface', function () {
-    it('exposes only the documented meta keys for simple pagination', function () {
+    it('exposes exactly the meta keys the spec documents', function (string $paginationType) {
+        $documented = documentedPaginationMetaKeys($paginationType);
+
         $response = $this->getJson('/api/v1/invoices', [
-            'x-pagination' => 'simple',
+            'x-pagination' => $paginationType,
         ]);
 
         $response->assertOk();
 
-        expect(array_keys($response->json('meta')))
-            ->toEqualCanonicalizing(['current_page', 'from', 'path', 'per_page', 'to']);
-    });
+        expect(array_keys($response->json('meta')))->toEqualCanonicalizing($documented);
+    })->with(['simple', 'table', 'cursor']);
 
-    it('exposes only the documented meta keys for simple pagination in camelCase', function () {
+    it('exposes exactly the meta keys the spec documents in camelCase', function (string $paginationType) {
         config(['openapi.schemas.default.config.pagination_response.casing' => 'camel']);
 
+        $documented = documentedPaginationMetaKeys($paginationType);
+
         $response = $this->getJson('/api/v1/invoices', [
-            'x-pagination' => 'simple',
+            'x-pagination' => $paginationType,
         ]);
 
         $response->assertOk();
 
-        expect(array_keys($response->json('meta')))
-            ->toEqualCanonicalizing(['currentPage', 'from', 'path', 'perPage', 'to']);
-    });
-
-    it('exposes only the documented meta keys for table pagination', function () {
-        $response = $this->getJson('/api/v1/invoices', [
-            'x-pagination' => 'table',
-        ]);
-
-        $response->assertOk();
-
-        expect(array_keys($response->json('meta')))
-            ->toEqualCanonicalizing(['current_page', 'from', 'last_page', 'path', 'per_page', 'to', 'total']);
-    });
-
-    it('exposes only the documented meta keys for cursor pagination', function () {
-        $response = $this->getJson('/api/v1/invoices', [
-            'x-pagination' => 'cursor',
-        ]);
-
-        $response->assertOk();
-
-        expect(array_keys($response->json('meta')))
-            ->toEqualCanonicalizing(['next_cursor', 'path', 'per_page', 'prev_cursor']);
-    });
+        expect(array_keys($response->json('meta')))->toEqualCanonicalizing($documented);
+    })->with(['simple', 'table', 'cursor']);
 });

--- a/tests/Feature/Http/Endpoints/PaginationTest.php
+++ b/tests/Feature/Http/Endpoints/PaginationTest.php
@@ -485,3 +485,51 @@ describe('Pagination Links with Query String', function () {
             ->and($links['first'])->not->toBeNull();
     });
 });
+
+describe('Pagination Meta Surface', function () {
+    it('exposes only the documented meta keys for simple pagination', function () {
+        $response = $this->getJson('/api/v1/invoices', [
+            'x-pagination' => 'simple',
+        ]);
+
+        $response->assertOk();
+
+        expect(array_keys($response->json('meta')))
+            ->toEqualCanonicalizing(['current_page', 'from', 'path', 'per_page', 'to']);
+    });
+
+    it('exposes only the documented meta keys for simple pagination in camelCase', function () {
+        config(['openapi.schemas.default.config.pagination_response.casing' => 'camel']);
+
+        $response = $this->getJson('/api/v1/invoices', [
+            'x-pagination' => 'simple',
+        ]);
+
+        $response->assertOk();
+
+        expect(array_keys($response->json('meta')))
+            ->toEqualCanonicalizing(['currentPage', 'from', 'path', 'perPage', 'to']);
+    });
+
+    it('exposes only the documented meta keys for table pagination', function () {
+        $response = $this->getJson('/api/v1/invoices', [
+            'x-pagination' => 'table',
+        ]);
+
+        $response->assertOk();
+
+        expect(array_keys($response->json('meta')))
+            ->toEqualCanonicalizing(['current_page', 'from', 'last_page', 'path', 'per_page', 'to', 'total']);
+    });
+
+    it('exposes only the documented meta keys for cursor pagination', function () {
+        $response = $this->getJson('/api/v1/invoices', [
+            'x-pagination' => 'cursor',
+        ]);
+
+        $response->assertOk();
+
+        expect(array_keys($response->json('meta')))
+            ->toEqualCanonicalizing(['next_cursor', 'path', 'per_page', 'prev_cursor']);
+    });
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Illuminate\Support\Str;
+use Symfony\Component\Yaml\Yaml;
+use Xentral\LaravelApi\OpenApi\OpenApiGeneratorFactory;
 use Xentral\LaravelApi\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__.'/Feature');
@@ -21,4 +24,42 @@ function buildFilterQuery(array $filters): string
 function workbench_dir(): string
 {
     return dirname(__DIR__).'/workbench';
+}
+
+/**
+ * Reads the documented meta keys for one pagination type out of the generated
+ * OpenAPI spec, so runtime assertions cannot drift from the schemas in
+ * PaginationResponseProcessor. Cached per casing, the only config that changes
+ * the generated key names.
+ *
+ * @return list<string>
+ */
+function documentedPaginationMetaKeys(string $paginationType): array
+{
+    static $cache = [];
+
+    $casing = config('openapi.schemas.default.config.pagination_response.casing', 'snake');
+
+    if (! isset($cache[$casing])) {
+        $generator = (new OpenApiGeneratorFactory)->create(config('openapi.schemas.default'));
+        $spec = Yaml::parse($generator->generate([workbench_dir()])->toYaml());
+        $schema = $spec['paths']['/api/v1/invoices']['get']['responses'][200]['content']['application/json']['schema'];
+
+        foreach ($schema['anyOf'] ?? [] as $branch) {
+            $type = Str::after($branch['title'] ?? '', 'Paginated Response: ');
+            $cache[$casing][$type] = array_keys($branch['properties']['meta']['properties'] ?? []);
+        }
+    }
+
+    $keys = $cache[$casing][$paginationType] ?? [];
+
+    if ($keys === []) {
+        throw new RuntimeException(
+            "The generated spec documents no meta keys for '{$paginationType}' pagination. "
+            .'Either the pagination type is gone or the response schema shape changed; '
+            .'fix this helper rather than letting the assertion pass vacuously.'
+        );
+    }
+
+    return $keys;
 }


### PR DESCRIPTION
Fixes [API-723](https://xentral.atlassian.net/browse/API-723).

## Problem

Laravel 12's simple paginator added `current_page_url` to `Paginator::toArray()`. `PaginatedResourceResponse::meta()` stripped only `data` and the four `*_page_url` link keys, so the new key survived and was camelCased into an undocumented `currentPageUrl` on the `meta` of every v3 list endpoint using simple pagination.

Writing the test for it surfaced a second leak from the same root cause: `LengthAwarePaginator::toArray()` emits a `links` collection, which the blocklist also missed. Table-paginated responses were returning a `meta.links` array of `{url, label, active, page}` objects — undocumented, and duplicating the top-level `links` object.

## Fix

`meta()` now allowlists via `Arr::only()` instead of blocklisting via `Arr::except()`. The allowlist is the union of the three documented meta schemas in `PaginationResponseProcessor::getPaginationProperties()`, and `apiPaginate()` returns only those three paginators, so runtime meta matches the generated spec key-for-key and future additions to Laravel's `toArray()` cannot leak again.

| Pagination type | Leaked before | After |
| --- | --- | --- |
| simple | `currentPageUrl` | clean |
| table | `meta.links` | clean |
| cursor | — | clean |

Meta supplied by endpoints through `additional(['meta' => ...])` is merged after `meta()` in the base class's `toResponse()`, so it is unaffected.

## Contract note

Dropping `meta.links` from table-paginated responses goes beyond what API-723 asked for and removes a field that was populated at runtime. It was never in the OpenAPI specs and nothing in this package consumes it, but any external consumer reading `meta.links` would be affected. Chose to fix it here rather than leave a known leak of the same class behind — flagging it explicitly for the review.

## Also

Dropped a duplicated `->withQueryString()->withQueryString()` on the table and cursor branches of `apiPaginate()`. No behavior change; the existing "Pagination Links with Query String" tests cover both branches.

## Testing

Four new `Pagination Meta Surface` tests assert the exact meta key set per pagination type. Three failed before the fix for the expected reason; the cursor case passed from the start, since `CursorPaginator::toArray()` never leaked.

- `vendor/bin/pest` — 489 passed, 1496 assertions
- `vendor/bin/pint --dirty` — passed
- `vendor/bin/phpstan analyse` — no errors


[API-723]: https://xentral.atlassian.net/browse/API-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ